### PR TITLE
MCS-515 - Update table to use same table component that is on query builder page

### DIFF
--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResults.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResults.jsx
@@ -34,7 +34,8 @@ const Results = ({queryObj}) => {
                     optionsToAdd.push({value: "scene." + key, label: data[complexQueryName].sceneMap[key]});
                 }
 
-                const options = noneOption.concat(optionsToAdd.sort((a, b) => (a.label > b.label) ? 1 : -1));
+                const groupByOptions = noneOption.concat(optionsToAdd.sort((a, b) => (a.label > b.label) ? 1 : -1));
+                const displayOptions = {showAnalysisPageLink: true};
 
                 if(resultsData.length === 0) {
                     return (
@@ -49,7 +50,7 @@ const Results = ({queryObj}) => {
                                     Display: {resultsData.length} Results
                                 </div>
                             </div>
-                            <QueryResultsTable columns={columns} rows={resultsData} groupByOptions={options}/>
+                            <QueryResultsTable columns={columns} rows={resultsData} groupByOptions={groupByOptions} displayOptions={displayOptions}/>
                         </div>
                     );
                 }

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -219,6 +219,19 @@ class QueryResultsTable extends React.Component {
         return newStr;
     }
 
+    convertObjectToString = (objectToConvert) => {
+        let newStr = "";
+        Object.keys(objectToConvert).forEach((key, index) => {
+            newStr = newStr + key + ": " + this.convertValueToString(objectToConvert[key]);
+
+            if(index < Object.keys(objectToConvert).length - 1) {
+                newStr = newStr + ", ";
+            }
+        })
+
+        return newStr;
+    }
+
     convertValueToString = (valueToConvert) => {
         if(Array.isArray(valueToConvert) && valueToConvert !== null) {
             return this.convertArrayToString(valueToConvert);

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -188,6 +188,22 @@ class QueryResultsTable extends React.Component {
         }
     }
 
+    getButtonText = (value) => {
+        if(this.props.displayOptions.buttonLabelHandler) {
+            return this.props.displayOptions.buttonLabelHandler(value);
+        } else {
+            return value;
+        }
+    }
+
+    getButtonClass = (value) => {
+        if(this.props.displayOptions.buttonClassHandler) {
+            return this.props.displayOptions.buttonClassHandler(value);
+        } else {
+            return "btn btn-secondary"
+        }
+    }
+
     render() {
         let { rows, columns } = this.props;
         let columnData = this.getColumnData(columns);
@@ -208,14 +224,17 @@ class QueryResultsTable extends React.Component {
                     <Table>
                         <TableHead>
                             <TableRow>
+                            {this.props.displayOptions !== undefined 
+                                && this.props.displayOptions.showAnalysisPageLink === true && 
                                 <TableCell key='result_table_cell_link' className="results-table-header-cell">
                                     Analysis Page Link
-                                </TableCell>
+                                </TableCell>}
 
                                 {columnData.map((item, key) => (
                                     <TableCell key={'result_table_cell_' + key} className="results-table-header-cell">
                                         <TableSortLabel active={sortBy === item.dataKey} direction={sortOrder} 
-                                            onClick={this.handleRequestSort.bind(null, item.dataKey)}>{item.title}
+                                            onClick={this.handleRequestSort.bind(null, item.dataKey)}>
+                                                {item.title}
                                         </TableSortLabel>
                                     </TableCell>
                                 ))}
@@ -228,19 +247,38 @@ class QueryResultsTable extends React.Component {
                                         groupedData.slice(this.state.page * this.state.rowsPerPage, 
                                             this.state.page * this.state.rowsPerPage + this.state.rowsPerPage) : groupedData).map((rowItem, rowKey) => (
                                         <TableRow key={'table_row_' + rowKey}>
-                                            <TableCell key={'table_cell_' + rowKey + "_link"}>
-                                                <ToolTipWithStyles arrow={true} title='View Details' placement='right'>
-                                                    <div className="table-cell-wrap-text">
-                                                        <Link to={this.getAnalysisPageURL(rowItem)} target="_blank">View Details</Link>
-                                                    </div>
-                                                </ToolTipWithStyles>
-                                            </TableCell>
+                                            {this.props.displayOptions !== undefined &&
+                                                this.props.displayOptions.showAnalysisPageLink === true && 
+                                                <TableCell key={'table_cell_' + rowKey + "_link"}>
+                                                    <ToolTipWithStyles arrow={true} title='View Details' placement='right'>
+                                                        <div className="table-cell-wrap-text">
+                                                            <Link to={this.getAnalysisPageURL(rowItem)} target="_blank">View Details</Link>
+                                                        </div>
+                                                    </ToolTipWithStyles>
+                                                </TableCell>
+                                            }
 
                                             {columnData.map((columnItem, columnKey) => (
                                                 <TableCell key={'table_cell_' + rowKey + "_" + columnKey}>
                                                     <ToolTipWithStyles arrow={true} title={this.getToolTipTextForTable(rowItem, columnItem.dataKey)} placement='right'>
                                                         <div className="table-cell-wrap-text">
-                                                            {_.get(rowItem, columnItem.dataKey)}
+                                                            {this.props.displayOptions !== undefined &&
+                                                                this.props.displayOptions.includeButton === true && 
+                                                                columnItem.dataKey === this.props.displayOptions.columnKey &&
+                                                                this.props.displayOptions.buttonClickHandler &&
+                                                            <button key={columnItem.dataKey + "_button_" + _.get(rowItem, columnItem.dataKey)} 
+                                                                className={this.getButtonClass(_.get(rowItem, columnItem.dataKey))}
+                                                                id={columnItem.dataKey + "_btn_" + _.get(rowItem, columnItem.dataKey)} 
+                                                                type="button"
+                                                                onClick={() => this.props.displayOptions.buttonClickHandler(_.get(rowItem, columnItem.dataKey))}>
+                                                                    {this.getButtonText(_.get(rowItem, columnItem.dataKey))}
+                                                            </button>}
+                                                            {((this.props.displayOptions === undefined ||
+                                                                this.props.displayOptions.includeButton !== true) ||
+                                                                (this.props.displayOptions.includeButton === true && 
+                                                                columnItem.dataKey !== this.props.displayOptions.columnKey)) &&
+                                                                _.get(rowItem, columnItem.dataKey)
+                                                            }
                                                         </div>
                                                     </ToolTipWithStyles>
                                                 </TableCell>

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -87,6 +87,7 @@ TablePaginationActions.propTypes = {
     rowsPerPage: PropTypes.number.isRequired
 };
 
+// TODO: rename to be more generic?
 class QueryResultsTable extends React.Component {
     constructor(props) {
         super(props);

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -204,6 +204,65 @@ class QueryResultsTable extends React.Component {
         }
     }
 
+    convertArrayToString = (arrayToConvert) => {
+        let newStr = "";
+        for(let i=0; i < arrayToConvert.length; i++) {
+            newStr = newStr + this.convertValueToString(arrayToConvert[i]);
+
+            if(i < arrayToConvert.length -1) {
+                newStr = newStr + ", ";
+            }
+        }
+
+        return newStr;
+    }
+
+    convertValueToString = (valueToConvert) => {
+        if(Array.isArray(valueToConvert) && valueToConvert !== null) {
+            return this.convertArrayToString(valueToConvert);
+        }
+
+        if(typeof valueToConvert === 'object' && valueToConvert !== null) {
+            return this.convertObjectToString(valueToConvert);
+        }
+
+        if(valueToConvert === true) {
+            return "true";
+        } 
+
+        if(valueToConvert === false) {
+            return "false";
+        } 
+
+        if(!isNaN(valueToConvert)) {
+            return Math.floor(valueToConvert * 100) / 100;
+        }
+
+        return valueToConvert;
+    }
+
+    displayItemText(row, dataKey) {
+        let item = _.get(row, dataKey);
+        
+        if(item !== undefined && item !== null) {
+            return this.convertValueToString(item);
+        } else {
+            return "";
+        }
+    }
+
+    getToolTipTextForTable = (rowItem, key) => {
+        return this.displayItemText(rowItem, key);
+    }
+
+    getCellTextClass = () => {
+        if(this.props.displayOptions && this.props.displayOptions.displayItemFullText === true) {
+            return "";
+        } else {
+            return "table-cell-wrap-text";
+        }
+    }
+
     render() {
         let { rows, columns } = this.props;
         let columnData = this.getColumnData(columns);
@@ -251,7 +310,7 @@ class QueryResultsTable extends React.Component {
                                                 this.props.displayOptions.showAnalysisPageLink === true && 
                                                 <TableCell key={'table_cell_' + rowKey + "_link"}>
                                                     <ToolTipWithStyles arrow={true} title='View Details' placement='right'>
-                                                        <div className="table-cell-wrap-text">
+                                                        <div className={this.getCellTextClass()}>
                                                             <Link to={this.getAnalysisPageURL(rowItem)} target="_blank">View Details</Link>
                                                         </div>
                                                     </ToolTipWithStyles>
@@ -261,7 +320,7 @@ class QueryResultsTable extends React.Component {
                                             {columnData.map((columnItem, columnKey) => (
                                                 <TableCell key={'table_cell_' + rowKey + "_" + columnKey}>
                                                     <ToolTipWithStyles arrow={true} title={this.getToolTipTextForTable(rowItem, columnItem.dataKey)} placement='right'>
-                                                        <div className="table-cell-wrap-text">
+                                                        <div className={this.getCellTextClass()}>
                                                             {this.props.displayOptions !== undefined &&
                                                                 this.props.displayOptions.includeButton === true && 
                                                                 columnItem.dataKey === this.props.displayOptions.columnKey &&
@@ -271,13 +330,13 @@ class QueryResultsTable extends React.Component {
                                                                 id={columnItem.dataKey + "_btn_" + _.get(rowItem, columnItem.dataKey)} 
                                                                 type="button"
                                                                 onClick={() => this.props.displayOptions.buttonClickHandler(_.get(rowItem, columnItem.dataKey))}>
-                                                                    {this.getButtonText(_.get(rowItem, columnItem.dataKey))}
+                                                                    {this.getButtonText(this.displayItemText(rowItem, columnItem.dataKey))}
                                                             </button>}
                                                             {((this.props.displayOptions === undefined ||
                                                                 this.props.displayOptions.includeButton !== true) ||
                                                                 (this.props.displayOptions.includeButton === true && 
                                                                 columnItem.dataKey !== this.props.displayOptions.columnKey)) &&
-                                                                _.get(rowItem, columnItem.dataKey)
+                                                                this.displayItemText(rowItem, columnItem.dataKey)
                                                             }
                                                         </div>
                                                     </ToolTipWithStyles>
@@ -312,7 +371,7 @@ class QueryResultsTable extends React.Component {
                                                     {columnData.map((columnItem, columnKey) => (
                                                         <TableCell key={'table_cell_' + rowKey + "_" + columnKey}>
                                                             <ToolTipWithStyles arrow={true} title={this.getToolTipTextForTable(rowItem, columnItem.dataKey)} placement='right'>
-                                                                <div className="table-cell-wrap-text">
+                                                                <div className={this.getCellTextClass()}>
                                                                     {_.get(rowItem, columnItem.dataKey)}
                                                                 </div>
                                                             </ToolTipWithStyles>

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -93,11 +93,11 @@ const tableCols = [
     { dataKey: 'scene.goal.sceneInfo.slices', title: 'Slices'},
     { dataKey: 'score.classification', title: 'Answer' },
     { dataKey: 'score.score_description', title: 'Score'},
-    { dataKey: 'score.confidence', title: 'Confidence' },
-    { dataKey: 'score.mse_loss', title: 'MSE'}
+    { dataKey: 'score.confidence', title: 'Confidence' }
 ]
 
 const groupingOptions = [
+    { value: '', label: 'None' },
     { value: 'score.classification', label: 'Answer' },
     { value: 'score.score_description', label: 'Score'},
     { value: 'score.confidence', label: 'Confidence' }

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -91,14 +91,14 @@ const tableCols = [
     { dataKey: 'scene_num', title: 'Scene' },
     { dataKey: 'scene_goal_id', title: 'Goal ID'},
     { dataKey: 'scene.goal.sceneInfo.slices', title: 'Slices'},
-    { dataKey: 'score.classification', title: 'Answer' },
+    { dataKey: 'score.classification', title: 'Classification' },
     { dataKey: 'score.score_description', title: 'Score'},
     { dataKey: 'score.confidence', title: 'Confidence' }
 ]
 
 const groupingOptions = [
     { value: '', label: 'None' },
-    { value: 'score.classification', label: 'Answer' },
+    { value: 'score.classification', label: 'Classification' },
     { value: 'score.score_description', label: 'Score'},
     { value: 'score.confidence', label: 'Confidence' }
 ]

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -43,29 +43,6 @@ const create_complex_query = gql`
         createComplexQuery(queryObject: $queryObject, projectionObject: $projectionObject) 
     }`;
 
-const mcs_history = gql`
-    query getEval3History($categoryType: String!, $sceneNum: Int!){
-        getEval3History(categoryType: $categoryType, sceneNum: $sceneNum) {
-            eval
-            performer
-            name
-            test_type
-            scene_num
-            scene_part_num
-            score
-            steps
-            flags
-            step_counter
-            category
-            category_type
-            category_pair
-            scene_goal_id
-            metadata
-            filename
-            fileTimestamp
-        }
-  }`;
-
 const mcs_scene= gql`
     query getEval3Scene($sceneName: String, $sceneNum: Int){
         getEval3Scene(sceneName: $sceneName, sceneNum: $sceneNum) {
@@ -470,14 +447,14 @@ class ScenesEval3 extends React.Component {
                                                         <div className="scene-text">Links for other videos:</div>
                                                             <div className="scene-text">
                                                                 <a href={
-                                                                    this.getVideoFileName(scenesByPerformer, "_heatmap_")} target="_blank">Heatmap</a>
+                                                                    this.getVideoFileName(scenesByPerformer, "_heatmap_")} target="_blank" rel="noopener noreferrer">Heatmap</a>
                                                             </div>
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank">Depth</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank" rel="noopener noreferrer">Depth</a>
                                                             </div>
                                                             {this.state.currentMetadataLevel !== "" && this.state.currentMetadataLevel !== "level1" && 
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank">Segmentation</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank" rel="noopener noreferrer">Segmentation</a>
                                                             </div>}
                                                     </div> 
                                                 }
@@ -541,11 +518,11 @@ class ScenesEval3 extends React.Component {
                                                             </div>
                                                             <div className="scene-text">Links for other videos:</div>
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank">Depth</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank" rel="noopener noreferrer">Depth</a>
                                                             </div>
                                                             {this.state.currentMetadataLevel !== "" && this.state.currentMetadataLevel !== "level1" && 
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank">Segmentation</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank" rel="noopener noreferrer">Segmentation</a>
                                                             </div>} 
                                                         </div>
                                                     }

--- a/mcs_docker_setup/analysis-ui/src/css/app.css
+++ b/mcs_docker_setup/analysis-ui/src/css/app.css
@@ -277,6 +277,10 @@ ol, ul {
     margin: 5px 10px 10px 10px;
 }
 
+.score-header-btn-group {
+    padding-bottom: 40px;
+}
+
 .score-table-div .table, .object-contents .table {
     border: 1px solid black;
     padding: 5px 15px 5px 15px; 

--- a/mcs_docker_setup/node-graphql/server.schema.js
+++ b/mcs_docker_setup/node-graphql/server.schema.js
@@ -139,7 +139,7 @@ const mcsTypeDefs = gql`
     getSceneFieldAggregation(fieldName: String) : [StringOrFloat]
     getAllHistoryFields: [dropDownObj]
     getAllSceneFields: [dropDownObj],
-    createComplexQuery(queryObject: JSON): JSON
+    createComplexQuery(queryObject: JSON, projectionObject: JSON): JSON
     getHomeStats(eval: String): homeStatsObject
     getSavedQueries: [savedQueryObj]
     getScenesAndHistoryTypes: [dropDownObj]
@@ -285,6 +285,12 @@ const mcsResolvers = {
         },
         createComplexQuery: async(obj, args, context, infow)=> {
             mongoQueryObject = createComplexMongoQuery(args['queryObject']);
+
+            if(args['projectionObject']) {
+                complexQueryProjectionObject = args['projectionObject'];
+            } else {
+                complexQueryProjectionObject = null;
+            }
 
             async function getComplexResults() {
                 if(complexQueryProjectionObject === null ){


### PR DESCRIPTION
Had some issues with this initially, and ended up using the QueryResultsTable component itself and trying to generalize things a bit more. May have not been worth it (if not, I can create a new table component for the scenes view instead).

I also messed with the fields/labels we're displaying in the scores table, and added back in the complexQuery to display the slices data within the scores table. 

