### PR TITLE
MCS-524 - Initial table for classification by step

### DIFF
--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -480,10 +480,10 @@ class ScenesEval3 extends React.Component {
 
                                                 { (this.checkIfScenesExist(scenesByPerformer) 
                                                     && scenesByPerformer[this.state.currentMetadataLevel][this.state.currentPerformer][0]["category"] !== "interactive") && 
-                                                    <div className="scores-by-step">
+                                                    <div className="classification-by-step">
                                                         <Accordion defaultActiveKey="0">
                                                             <Card>
-                                                                <Accordion.Toggle as={Card.Header} className="scores-by-step-header" eventKey="0">
+                                                                <Accordion.Toggle as={Card.Header} className="classification-by-step-header" eventKey="0">
                                                                     <div>
                                                                         <div>
                                                                             <h3>Selected Scene Classification by Step</h3>
@@ -508,16 +508,16 @@ class ScenesEval3 extends React.Component {
                                                                                 </thead>
                                                                                 <tbody>
                                                                                     {this.getSceneHistoryItem(scenesByPerformer) !== undefined && this.getSceneHistoryItem(scenesByPerformer) !== null
-                                                                                        && this.getSceneHistoryItem(scenesByPerformer).steps.map((stepScoreObj, key) => 
-                                                                                        <tr key={'performer_score_by_step_row_' + key}>
-                                                                                            <td>{stepScoreObj.stepNumber}</td>
-                                                                                            <td>{stepScoreObj.action}</td>
-                                                                                            <td>{stepScoreObj.classification}</td>
-                                                                                            <td>{stepScoreObj.confidence}</td>
+                                                                                        && this.getSceneHistoryItem(scenesByPerformer).steps.map((stepObj, key) => 
+                                                                                        <tr key={'performer_classification_by_step_row_' + key}>
+                                                                                            <td>{stepObj.stepNumber}</td>
+                                                                                            <td>{stepObj.action}</td>
+                                                                                            <td>{stepObj.classification}</td>
+                                                                                            <td>{stepObj.confidence}</td>
                                                                                             <td>
-                                                                                                {stepScoreObj.action !== 'EndHabituation' && stepScoreObj.violations_xy_list !== undefined
-                                                                                                && stepScoreObj.violations_xy_list !== null &&
-                                                                                                        this.convertXYArrayToString(stepScoreObj.violations_xy_list)                                                                     
+                                                                                                {stepObj.action !== 'EndHabituation' && stepObj.violations_xy_list !== undefined
+                                                                                                && stepObj.violations_xy_list !== null &&
+                                                                                                        this.convertXYArrayToString(stepObj.violations_xy_list)                                                                     
                                                                                                 }
                                                                                             </td>
                                                                                         </tr>

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -5,6 +5,9 @@ import _ from "lodash";
 import $ from 'jquery';
 //import FlagCheckboxMutation from './flagCheckboxMutation';
 import {EvalConstants} from './evalConstants';
+import Accordion from 'react-bootstrap/Accordion'
+import Button from 'react-bootstrap/Button'
+import Card from 'react-bootstrap/Card'
 
 const historyQueryName = "getEval3History";
 const sceneQueryName = "getEval3Scene";
@@ -310,6 +313,19 @@ class ScenesEval3 extends React.Component {
         }
     }
 
+    convertXYArrayToString = (arrayToConvert) => {
+        let newStr = "";
+        for(let i=0; i < arrayToConvert.length; i++) {
+            newStr = newStr + '(' + this.convertValueToString(arrayToConvert[i]) + ')';
+
+            if(i < arrayToConvert.length -1) {
+                newStr = newStr + ", ";
+            }
+        }
+
+        return newStr;
+    }
+
     render() {
         return (
             <Query query={mcs_history} variables={
@@ -461,6 +477,61 @@ class ScenesEval3 extends React.Component {
                                                         </tbody>
                                                     </table>
                                                 </div>
+
+                                                { (this.checkIfScenesExist(scenesByPerformer) 
+                                                    && scenesByPerformer[this.state.currentMetadataLevel][this.state.currentPerformer][0]["category"] !== "interactive") && 
+                                                    <div className="scores-by-step">
+                                                        <Accordion defaultActiveKey="0">
+                                                            <Card>
+                                                                <Accordion.Toggle as={Card.Header} className="scores-by-step-header" eventKey="0">
+                                                                    <div>
+                                                                        <div>
+                                                                            <h3>Selected Scene Score by Step</h3>
+                                                                        </div>
+                                                                        <div>
+                                                                            <h6>(Click Here to Expand/Collapse)</h6>
+                                                                        </div>
+                                                                    </div>
+                                                                </Accordion.Toggle>
+                                                                <Accordion.Collapse eventKey="0">
+                                                                    <Card.Body>
+                                                                        <div className="score-table-div">
+                                                                            <table className="score-table">
+                                                                                <thead>
+                                                                                    <tr>
+                                                                                        <th>Step Number</th>
+                                                                                        <th>Action</th>
+                                                                                        <th>Classification</th>
+                                                                                        <th>Confidence</th>
+                                                                                        <th>Violations ((x,y) list)</th>
+                                                                                    </tr>
+                                                                                </thead>
+                                                                                <tbody>
+                                                                                    {this.getSceneHistoryItem(scenesByPerformer) !== undefined && this.getSceneHistoryItem(scenesByPerformer) !== null
+                                                                                        && this.getSceneHistoryItem(scenesByPerformer).steps.map((stepScoreObj, key) => 
+                                                                                        <tr key={'performer_score_by_step_row_' + key}>
+                                                                                            <td>{stepScoreObj.stepNumber}</td>
+                                                                                            <td>{stepScoreObj.action}</td>
+                                                                                            <td>{stepScoreObj.classification}</td>
+                                                                                            <td>{stepScoreObj.confidence}</td>
+                                                                                            <td>
+                                                                                                {stepScoreObj.action !== 'EndHabituation' && stepScoreObj.violations_xy_list !== undefined
+                                                                                                && stepScoreObj.violations_xy_list !== null &&
+                                                                                                        this.convertXYArrayToString(stepScoreObj.violations_xy_list)                                                                     
+                                                                                                }
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    )}
+                                                                                </tbody>
+                                                                            </table>
+                                                                        </div>                            
+                                                                    </Card.Body>
+                                                                </Accordion.Collapse>
+                                                            </Card>
+                                                        </Accordion>
+                                                    </div>
+                                                }
+
                                                 <div className="scenes_header">
                                                     <h3>View Selected Scene Info</h3>
                                                 </div>

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -486,7 +486,7 @@ class ScenesEval3 extends React.Component {
                                                                 <Accordion.Toggle as={Card.Header} className="scores-by-step-header" eventKey="0">
                                                                     <div>
                                                                         <div>
-                                                                            <h3>Selected Scene Score by Step</h3>
+                                                                            <h3>Selected Scene Classification by Step</h3>
                                                                         </div>
                                                                         <div>
                                                                             <h6>(Click Here to Expand/Collapse)</h6>

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -453,7 +453,7 @@ class ScenesEval3 extends React.Component {
                                                             <tr>
                                                                 <th>Select Scene</th>
                                                                 <th>Goal Id</th>
-                                                                <th>Answer</th>
+                                                                <th>Classification</th>
                                                                 <th>Score</th>
                                                                 <th>Confidence</th>
                                                                 <th>MSE</th>

--- a/mcs_docker_setup/analysis-ui/src/css/app.css
+++ b/mcs_docker_setup/analysis-ui/src/css/app.css
@@ -912,3 +912,12 @@ ol, ul {
 .results-groupby-selector {
     width: 250px;
 }
+
+.scores-by-step {
+    margin: 20px 10px 20px 10px;
+    padding: 20px 0 20px 0;
+}
+
+.scores-by-step-header {
+    cursor: pointer;
+}

--- a/mcs_docker_setup/analysis-ui/src/css/app.css
+++ b/mcs_docker_setup/analysis-ui/src/css/app.css
@@ -913,11 +913,11 @@ ol, ul {
     width: 250px;
 }
 
-.scores-by-step {
+.classification-by-step {
     margin: 20px 10px 20px 10px;
     padding: 20px 0 20px 0;
 }
 
-.scores-by-step-header {
+.classification-by-step-header {
     cursor: pointer;
 }


### PR DESCRIPTION
Right now, just displaying everything in one big table that we can iterate on/cleanup later -- added an expand/collapse since the list can get a bit long for agency tasks.

Also, retitled "Answer" header in both tables to "Classification". 

Columns displayed: Step Number, Action, Classification, Confidence, Violations ((x,y) list)

(Didn't make this dependent on the MCS-524 table changes, but in case MCS-524 is merged before this, I can update this PR to use that table component instead). 