### PR TITLE
MCS-515 - Add sorting to scores table

### DIFF
--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -5,6 +5,12 @@ import _ from "lodash";
 import $ from 'jquery';
 //import FlagCheckboxMutation from './flagCheckboxMutation';
 import {EvalConstants} from './evalConstants';
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import TableSortLabel from "@material-ui/core/TableSortLabel";
 
 const historyQueryName = "getEval3History";
 const sceneQueryName = "getEval3Scene";
@@ -431,36 +437,39 @@ class ScenesEval3 extends React.Component {
                                                         </button>
                                                     )}
                                                 </div>
+
                                                 <div className="score-table-div">
-                                                    <table className="score-table">
-                                                        <thead>
-                                                            <tr>
-                                                                <th>Select Scene</th>
-                                                                <th>Goal Id</th>
-                                                                <th>Answer</th>
-                                                                <th>Score</th>
-                                                                <th>Confidence</th>
-                                                                <th>MSE</th>
-                                                            </tr>
-                                                        </thead>
-                                                        <tbody>
-                                                            {this.checkIfScenesExist(scenesByPerformer) && scenesByPerformer[this.state.currentMetadataLevel][this.state.currentPerformer].map((scoreObj, key) => 
-                                                                <tr key={'peformer_score_row_' + key}>
-                                                                    <td>
-                                                                        <button key={"scene_button_" + scoreObj.scene_num} 
-                                                                            className={this.state.currentSceneNum === scoreObj.scene_num - 1 ? 'btn btn-primary active' : 'btn btn-secondary'}
-                                                                        id={"scene_btn_" + scoreObj.scene_num} type="button" onClick={() => this.changeScene(scoreObj.scene_num - 1)}>Scene {scoreObj.scene_num}</button>
-                                                                    </td>
-                                                                    <td>{scoreObj.scene_goal_id}</td>
-                                                                    <td>{scoreObj.score.classification}</td>
-                                                                    <td>{scoreObj.score.score_description}</td>
-                                                                    <td>{scoreObj.score.confidence}</td>
-                                                                    <td>{scoreObj.score.mse_loss}</td>
-                                                                </tr>
-                                                            )}
-                                                        </tbody>
-                                                    </table>
+                                                    <Table className="score-table" aria-label="simple table">
+                                                        <TableHead>
+                                                            <TableRow>
+                                                                <TableCell>Select Scene</TableCell>
+                                                                <TableCell>Goal Id</TableCell>
+                                                                <TableCell>Answer</TableCell>
+                                                                <TableCell>Score</TableCell>
+                                                                <TableCell>Confidence</TableCell>
+                                                                <TableCell>MSE</TableCell>
+                                                            </TableRow>
+                                                        </TableHead>
+                                                        <TableBody>
+                                                        {this.checkIfScenesExist(scenesByPerformer) && scenesByPerformer[this.state.currentMetadataLevel][this.state.currentPerformer].map((scoreObj, key) => 
+                                                            <TableRow key={'peformer_score_row_' + key}>
+                                                                <TableCell>
+                                                                <button key={"scene_button_" + scoreObj.scene_num} 
+                                                                    className={this.state.currentSceneNum === scoreObj.scene_num - 1 ? 'btn btn-primary active' : 'btn btn-secondary'}
+                                                                    id={"scene_btn_" + scoreObj.scene_num} type="button" onClick={() => this.changeScene(scoreObj.scene_num - 1)}>Scene {scoreObj.scene_num}</button>
+                                                                </TableCell>
+                                                                <TableCell>{scoreObj.scene_goal_id}</TableCell>
+                                                                <TableCell>{scoreObj.score.classification}</TableCell>
+                                                                <TableCell>{scoreObj.score.score_description}</TableCell>
+                                                                <TableCell>{scoreObj.score.confidence}</TableCell>
+                                                                <TableCell>{scoreObj.score.mse_loss}</TableCell>
+                                                            </TableRow>
+                                                        )}
+                                                        </TableBody>
+                                                    </Table>      
                                                 </div>
+            
+
                                                 <div className="scenes_header">
                                                     <h3>View Selected Scene Info</h3>
                                                 </div>

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -388,7 +388,7 @@ class ScenesEval3 extends React.Component {
                         this.props.value.scene_num
                     ), 
                     "projectionObject": projectionObject
-                }} fetchPolicy='network-only'>
+                }}>
             {
                 ({ loading, error, data }) => {
                     if (loading) return <div>Loading ...</div> 

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -12,13 +12,41 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
 
-const historyQueryName = "getEval3History";
+const historyQueryName = "createComplexQuery";
+const historyQueryResults = "results";
 const sceneQueryName = "getEval3Scene";
 
 let constantsObject = {};
 //let currentState = {};
 let currentStep = 0;
 let currentTime = 0;
+
+const projectionObject = {
+    "eval": 1,
+    "performer": 1,
+    "name": 1,
+    "test_type": 1,
+    "scene_num": 1,
+    "scene_part_num": 1,
+    "scene_goal_id": 1,
+    "score": 1,
+    "steps": 1,
+    "flags": 1,
+    "metadata": 1,
+    "step_counter": 1,
+    "category": 1,
+    "category_type": 1,
+    "category_pair": 1,
+    "fullFilename": 1,
+    "filename": 1,
+    "fileTimestamp": 1,
+    "scene.goal.sceneInfo.slices": "$mcsScenes.goal.sceneInfo.slices"
+}
+
+const create_complex_query = gql`
+    query createComplexQuery($queryObject: JSON!, $projectionObject: JSON!) {
+        createComplexQuery(queryObject: $queryObject, projectionObject: $projectionObject) 
+    }`;
 
 const mcs_history = gql`
     query getEval3History($categoryType: String!, $sceneNum: Int!){
@@ -73,7 +101,7 @@ function getSorting(order, orderBy) {
 const scoreTableCols = [
     { dataKey: 'scene_num', title: 'Scene' },
     { dataKey: 'scene_goal_id', title: 'Goal ID'},
-    //{ dataKey: 'scene.goal.sceneInfo.slices', title: 'Slices'},
+    { dataKey: 'scene.goal.sceneInfo.slices', title: 'Slices'},
     { dataKey: 'score.classification', title: 'Classification' },
     { dataKey: 'score.score_description', title: 'Score'},
     { dataKey: 'score.confidence', title: 'Confidence' }
@@ -185,6 +213,16 @@ class ScenesEval3 extends React.Component {
         }
 
         return valueToConvert;
+    }
+
+    displayItemText(row, dataKey) {
+        let item = _.get(row, dataKey);
+
+        if(item !== undefined && item !== null) {
+            return this.convertValueToString(item);
+        } else {
+            return "";
+        }
     }
 
     findObjectTabName = (sceneObject) => {
@@ -343,16 +381,20 @@ class ScenesEval3 extends React.Component {
 
     render() {
         return (
-            <Query query={mcs_history} variables={
-                {   "categoryType":  this.props.value.category_type,
-                    "sceneNum": parseInt(this.props.value.scene_num)
+            <Query query={create_complex_query} variables={
+                {    
+                    "queryObject":  this.getSceneHistoryQueryObject(
+                        this.props.value.category_type,
+                        this.props.value.scene_num
+                    ), 
+                    "projectionObject": projectionObject
                 }} fetchPolicy='network-only'>
             {
                 ({ loading, error, data }) => {
                     if (loading) return <div>Loading ...</div> 
                     if (error) return <div>Error</div>
                     
-                    const evals = data[historyQueryName];
+                    const evals = data[historyQueryName][historyQueryResults];
                     //console.log(evals);
 
                     let sortedScenes =  _.sortBy(evals, "scene_part_num");
@@ -491,7 +533,7 @@ class ScenesEval3 extends React.Component {
                                                                         }
 
                                                                         {(col.dataKey !== "scene_num") &&
-                                                                            _.get(scoreObj, col.dataKey)
+                                                                            this.displayItemText(scoreObj, col.dataKey)
                                                                         }
                                                                     </TableCell>
                                                                 ))}

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -218,7 +218,7 @@ class ScenesEval3 extends React.Component {
     displayItemText(row, dataKey) {
         let item = _.get(row, dataKey);
 
-        if(item !== undefined && item !== null) {
+        if(item !== undefined && item !== null && item !== "") {
             return this.convertValueToString(item);
         } else {
             return "";
@@ -472,14 +472,14 @@ class ScenesEval3 extends React.Component {
                                                         <div className="scene-text">Links for other videos:</div>
                                                             <div className="scene-text">
                                                                 <a href={
-                                                                    this.getVideoFileName(scenesByPerformer, "_heatmap_")} target="_blank">Heatmap</a>
+                                                                    this.getVideoFileName(scenesByPerformer, "_heatmap_")} target="_blank" rel="noopener noreferrer">Heatmap</a>
                                                             </div>
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank">Depth</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank" rel="noopener noreferrer">Depth</a>
                                                             </div>
                                                             {this.state.currentMetadataLevel !== "" && this.state.currentMetadataLevel !== "level1" && 
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank">Segmentation</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank" rel="noopener noreferrer">Segmentation</a>
                                                             </div>}
                                                     </div> 
                                                 }
@@ -572,11 +572,11 @@ class ScenesEval3 extends React.Component {
                                                             </div>
                                                             <div className="scene-text">Links for other videos:</div>
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank">Depth</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_depth_")} target="_blank" rel="noopener noreferrer">Depth</a>
                                                             </div>
                                                             {this.state.currentMetadataLevel !== "" && this.state.currentMetadataLevel !== "level1" && 
                                                             <div className="scene-text">
-                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank">Segmentation</a>
+                                                                <a href={this.getVideoFileName(scenesByPerformer, "_segmentation_")} target="_blank" rel="noopener noreferrer">Segmentation</a>
                                                             </div>} 
                                                         </div>
                                                     }

--- a/mcs_docker_setup/node-graphql/server.mongoSyntax.js
+++ b/mcs_docker_setup/node-graphql/server.mongoSyntax.js
@@ -40,16 +40,29 @@ const createComplexMongoQuery = function(queryObj){
 
         switch(queryObj[i]["functionOperator"]) {
             case EQUALS:
-                const inObjList = queryObj[i]["fieldValue1"].split("__,__");
+                let inObjList;
+                if(isNaN(queryObj[i]["fieldValue1"])) {
+                    inObjList = queryObj[i]["fieldValue1"].split("__,__");
+                } else {
+                    inObjList = [queryObj[i]["fieldValue1"]]
+                }
+                let extraChecks = [];
                 for(let i = 0; i < inObjList.length; i++) {
-                    if(inObjList[i].toLowerCase() === "true") {
-                        inObjList[i] = true;
-                    }
-                    if(inObjList[i].toLowerCase() === "false") {
-                        inObjList[i] = false;
+                    if(isNaN(inObjList[i])){
+                        if(inObjList[i].toLowerCase() === "true") {
+                            inObjList[i] = true;
+                        }
+                        if(inObjList[i].toLowerCase() === "false") {
+                            inObjList[i] = false;
+                        }
+                    } else {
+                        if(parseFloat(inObjList[i]) !== NaN) {
+                            extraChecks.push(parseFloat(inObjList[i]))
+                        }
                     }
                 }
-                mQueryObj = {$in: inObjList};
+
+                mQueryObj = {$in: inObjList.concat(extraChecks)};
                 if(searchPrefix === scenesCollectionName) {
                     sceneQueryObj[searchPrefix +  queryObj[i]["fieldName"]] = mQueryObj;
                 } else {

--- a/mcs_docker_setup/node-graphql/server.schema.js
+++ b/mcs_docker_setup/node-graphql/server.schema.js
@@ -140,7 +140,7 @@ const mcsTypeDefs = gql`
     getAllHistoryFields: [dropDownObj]
     getAllSceneFields: [dropDownObj]
     getCollectionFields(collectionName: String): [dropDownObj]
-    createComplexQuery(queryObject: JSON): JSON
+    createComplexQuery(queryObject: JSON, projectionObject: JSON): JSON
     getHomeStats(eval: String): homeStatsObject
     getSavedQueries: [savedQueryObj]
     getScenesAndHistoryTypes: [dropDownObj]
@@ -314,6 +314,12 @@ const mcsResolvers = {
         },
         createComplexQuery: async(obj, args, context, infow)=> {
             mongoQueryObject = createComplexMongoQuery(args['queryObject']);
+
+            if(args['projectionObject']) {
+                complexQueryProjectionObject = args['projectionObject'];
+            } else {
+                complexQueryProjectionObject = null;
+            }
 
             async function getComplexResults() {
                 if(complexQueryProjectionObject === null ){


### PR DESCRIPTION
Opening new PR for MCS-515. Scores table is using Material UI and now has sorting. 

I also messed with the fields/labels we're displaying in the scores table (removed MSE and renamed 'Answer' to 'Classification'), and added back in the complexQuery to display the slices data within the scores table.