### PR TITLE
MCS-514 - Fix analysis UI URLs/test vs scene references

### DIFF
--- a/mcs_docker_setup/analysis-ui/src/components/App/commentsDisplay.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/commentsDisplay.jsx
@@ -74,7 +74,7 @@ const CommentBlockHolder = ({props}) => {
     if(props.value.test_type !== undefined && props.value.test_type !== null) {
         const queryVars = {
             "testType": props.value.test_type, 
-            "sceneNum": props.value.scene_num
+            "sceneNum": props.value.test_num
         };
 
         return (

--- a/mcs_docker_setup/analysis-ui/src/components/App/header.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/header.jsx
@@ -34,8 +34,10 @@ const GET_SUBMISSION_AGG = gql`
 class ListItem extends React.Component {
 
     updateState(item, stateName) {
-        this.props.state[stateName] = item;
-        this.props.updateHandler(stateName, item);
+        if(this.props.state[stateName] !== item) {
+            this.props.state[stateName] = item;
+            this.props.updateHandler(stateName, item);
+        }
     }
 
     render() {
@@ -57,66 +59,55 @@ class ListItem extends React.Component {
         } else {
             // Property List for Eval 2 Going Forward
             let hasEvalState = this.props.state["eval"] !== undefined && this.props.state["eval"] !== null;
+            let isEval2 = hasEvalState && this.props.state["eval"].includes("2");
+            let isEval3 = hasEvalState && this.props.state["eval"].includes("3");
             let hasTestTypeState = this.props.state["test_type"] !== undefined && this.props.state["test_type"] !== null;
             let hasCatTypeState = this.props.state["category_type"] !== undefined && this.props.state["category_type"] !== null;
             let hasTestNumState = this.props.state["test_num"] !== undefined && this.props.state["test_num"] !== null;
-            let hasSceneNumState = this.props.state["scene"] !== undefined && this.props.state["scene"] !== null;
             let paramsToAppend = '';
 
             if(this.props.stateName === 'eval') {
-                if(hasTestTypeState) {
+                let isValidEval2 = hasTestTypeState && this.props.item.includes("2");
+                let isValidEval3 = hasCatTypeState && this.props.item.includes("3");
+
+                if(isValidEval2) {
                     paramsToAppend += "&test_type=" + this.props.state["test_type"];
-                } else if(hasCatTypeState) {
+                } else if(isValidEval3) {
                     paramsToAppend += "&category_type=" + this.props.state["category_type"];
                 }
 
                 // TODO: rename scene_num/scene_part_num in mongo
-                if(hasTestNumState) {
+                if(hasTestNumState && (isValidEval2 || isValidEval3)) {
                     paramsToAppend += "&test_num=" + this.props.state["test_num"];
                 }
     
-                if(hasSceneNumState) {
-                    paramsToAppend += "&scene=" + this.props.state["scene"];
-                }
                 params = "?eval=" + this.props.item + paramsToAppend;
-            } else if(hasEvalState && this.props.stateName === 'test_type') {
+            } else if(hasEvalState && isEval2 && this.props.stateName === 'test_type') {
 
                 paramsToAppend += "&test_type=" + this.props.item;
 
                 if(hasTestNumState) {
                     paramsToAppend += "&test_num=" + this.props.state["test_num"];
                 }
-    
-                if(hasSceneNumState) {
-                    paramsToAppend += "&scene=" + this.props.state["scene"];
-                }
 
                 params = "?eval=" + this.props.state["eval"] + paramsToAppend;
-            } else if(hasEvalState && this.props.stateName === 'category_type') {
+            } else if(hasEvalState && isEval3 && this.props.stateName === 'category_type') {
 
                 paramsToAppend += "&category_type=" + this.props.item;
 
                 if(hasTestNumState) {
                     paramsToAppend += "&test_num=" + this.props.state["test_num"];
                 }
-    
-                if(hasSceneNumState) {
-                    paramsToAppend += "&scene=" + this.props.state["scene"];
-                }
 
                 params = "?eval=" + this.props.state["eval"] + paramsToAppend;
             } else if(hasEvalState && this.props.stateName === 'test_num') {
-                if(hasTestTypeState) {
+                if(hasTestTypeState && isEval2) {
                     paramsToAppend += "&test_type=" + this.props.state["test_type"];
-                } else if(hasCatTypeState) {
+                } else if(hasCatTypeState && isEval3) {
                     paramsToAppend += "&category_type=" + this.props.state["category_type"];
                 }
 
                 paramsToAppend += "&test_num=" + this.props.item;
-
-                if(hasSceneNumState) {
-                    paramsToAppend += "&scene=" + this.props.state["scene"];
-                }
 
                 params = "?eval=" + this.props.state["eval"] + paramsToAppend;
             }

--- a/mcs_docker_setup/analysis-ui/src/components/App/header.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/header.jsx
@@ -57,9 +57,10 @@ class ListItem extends React.Component {
         } else {
             // Property List for Eval 2 Going Forward
             let hasEvalState = this.props.state["eval"] !== undefined && this.props.state["eval"] !== null;
-            let hasSceneNumState = this.props.state["scene_num"] !== undefined && this.props.state["scene_num"] !== null;
             let hasTestTypeState = this.props.state["test_type"] !== undefined && this.props.state["test_type"] !== null;
             let hasCatTypeState = this.props.state["category_type"] !== undefined && this.props.state["category_type"] !== null;
+            let hasTestNumState = this.props.state["test_num"] !== undefined && this.props.state["test_num"] !== null;
+            let hasSceneNumState = this.props.state["scene"] !== undefined && this.props.state["scene"] !== null;
             let paramsToAppend = '';
 
             if(this.props.stateName === 'eval') {
@@ -68,18 +69,26 @@ class ListItem extends React.Component {
                 } else if(hasCatTypeState) {
                     paramsToAppend += "&category_type=" + this.props.state["category_type"];
                 }
+
+                // TODO: rename scene_num/scene_part_num in mongo
+                if(hasTestNumState) {
+                    paramsToAppend += "&test_num=" + this.props.state["test_num"];
+                }
     
                 if(hasSceneNumState) {
-                    // TODO: revisit calling param "scene_num" for eval 3 (should probably be "seq_num")
-                    paramsToAppend += "&scene_num=" + this.props.state["scene_num"];
+                    paramsToAppend += "&scene=" + this.props.state["scene"];
                 }
                 params = "?eval=" + this.props.item + paramsToAppend;
             } else if(hasEvalState && this.props.stateName === 'test_type') {
 
                 paramsToAppend += "&test_type=" + this.props.item;
 
+                if(hasTestNumState) {
+                    paramsToAppend += "&test_num=" + this.props.state["test_num"];
+                }
+    
                 if(hasSceneNumState) {
-                    paramsToAppend += "&scene_num=" + this.props.state["scene_num"];
+                    paramsToAppend += "&scene=" + this.props.state["scene"];
                 }
 
                 params = "?eval=" + this.props.state["eval"] + paramsToAppend;
@@ -87,19 +96,27 @@ class ListItem extends React.Component {
 
                 paramsToAppend += "&category_type=" + this.props.item;
 
+                if(hasTestNumState) {
+                    paramsToAppend += "&test_num=" + this.props.state["test_num"];
+                }
+    
                 if(hasSceneNumState) {
-                    paramsToAppend += "&scene_num=" + this.props.state["scene_num"];
+                    paramsToAppend += "&scene=" + this.props.state["scene"];
                 }
 
                 params = "?eval=" + this.props.state["eval"] + paramsToAppend;
-            } else if(hasEvalState && this.props.stateName === 'scene_num') {
+            } else if(hasEvalState && this.props.stateName === 'test_num') {
                 if(hasTestTypeState) {
                     paramsToAppend += "&test_type=" + this.props.state["test_type"];
                 } else if(hasCatTypeState) {
                     paramsToAppend += "&category_type=" + this.props.state["category_type"];
                 }
 
-                paramsToAppend += "&scene_num=" + this.props.item;
+                paramsToAppend += "&test_num=" + this.props.item;
+
+                if(hasSceneNumState) {
+                    paramsToAppend += "&scene=" + this.props.state["scene"];
+                }
 
                 params = "?eval=" + this.props.state["eval"] + paramsToAppend;
             }
@@ -217,17 +234,17 @@ class EvalNav extends React.Component {
 
                     {(this.props.state.eval !== undefined && this.props.state.eval !== null && this.props.state.eval.includes("2")) &&
                     <NavDropdown title={"Test Number: " + (
-                        (this.props.state.scene_num === undefined || this.props.state.scene_num === null) ? "None" : this.props.state.scene_num)}
+                        (this.props.state.test_num === undefined || this.props.state.test_num === null) ? "None" : this.props.state.test_num)}
                         id="basic-nav-dropdown">
-                        <DropListItems fieldName={"scene_num"} stateName={"scene_num"} state={this.props.state} updateHandler={this.props.updateHandler}/>
+                        <DropListItems fieldName={"scene_num"} stateName={"test_num"} state={this.props.state} updateHandler={this.props.updateHandler}/>
                     </NavDropdown>}
 
 
                     {(this.props.state.eval !== undefined && this.props.state.eval !== null && this.props.state.eval.includes("3")) &&
                     <NavDropdown title={"Test Number: " + (
-                        (this.props.state.scene_num === undefined || this.props.state.scene_num === null) ? "None" : this.props.state.scene_num)}
+                        (this.props.state.test_num === undefined || this.props.state.test_num === null) ? "None" : this.props.state.test_num)}
                         id="basic-nav-dropdown">
-                        <DropListItems fieldName={"scene_part_num"} stateName={"scene_num"} state={this.props.state} updateHandler={this.props.updateHandler}/>
+                        <DropListItems fieldName={"scene_part_num"} stateName={"test_num"} state={this.props.state} updateHandler={this.props.updateHandler}/>
                     </NavDropdown>}
                 </Nav>
             );

--- a/mcs_docker_setup/analysis-ui/src/components/App/index.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/index.jsx
@@ -66,6 +66,8 @@ const AnalysisUI = ({newState, updateHandler}) => {
     let hasTestType = (newState.test_type !== undefined && newState.test_type !== null)
     let hasTestNum = (newState.test_num !== undefined && newState.test_num !== null)
 
+    newState.history = history;
+
     // TODO: Fix comments for eval 3
     return <div>
         <div className="layout">
@@ -74,8 +76,8 @@ const AnalysisUI = ({newState, updateHandler}) => {
 
             <div className="layout-board">
                 { (newState.perf !== undefined && newState.perf !== null) && <Results value={newState}/>}
-                { (!isEval3) && hasTestType && hasTestNum && <Scenes value={newState}/> }
-                { isEval3 && hasCatType && hasTestNum && <ScenesEval3 value={newState}/> }
+                { (!isEval3) && hasTestType && hasTestNum && <Scenes value={newState} updateHandler={updateHandler}/> }
+                { isEval3 && hasCatType && hasTestNum && <ScenesEval3 value={newState} updateHandler={updateHandler}/> }
                 { newState.showComments && (!isEval3) && <CommentsComponent state={newState}/> }
             </div>
         </div>
@@ -206,12 +208,16 @@ export class App extends React.Component {
     }
 
     updateHandler(key, item) {
-        if(key === 'test_type' && this.doesStateHaveCategoryType()) {
+        if(key === 'eval') {
+            this.setState({ [key]: item, test_type: null, category_type: null, test_num: null, scene: null});
+        } else if(key === 'test_type' && this.doesStateHaveCategoryType()) {
             this.setState({ [key]: item, category_type: null, test_num: null, scene: null});
         } else if(key === 'category_type' && this.doesStateHaveTestType()) {
             this.setState({ [key]: item, test_type: null, test_num: null, scene: null});
-        } else {
+        } else if(key === 'scene') {
             this.setState({ [key]: item });
+        } else {
+            this.setState({ [key]: item, scene: null });
         }
     }
 

--- a/mcs_docker_setup/analysis-ui/src/components/App/index.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/index.jsx
@@ -42,8 +42,17 @@ const AnalysisUI = ({newState, updateHandler}) => {
             newState.category_type = params.category_type;
         }
     
+        // creating backwards compatability for old URLs with "scene_num" specified
         if(params.scene_num) {
-            newState.scene_num = params.scene_num;
+            newState.test_num = params.scene_num;
+        } else {
+            if(params.test_num) {
+                newState.test_num = params.test_num;
+            }
+    
+            if(params.scene) {
+                newState.scene = params.scene;
+            }
         }
     }
 
@@ -55,7 +64,7 @@ const AnalysisUI = ({newState, updateHandler}) => {
     let isEval3 = hasEval && newState.eval.includes("3");
     let hasCatType = (newState.category_type !== undefined && newState.category_type !== null)
     let hasTestType = (newState.test_type !== undefined && newState.test_type !== null)
-    let hasSceneNum = (newState.scene_num !== undefined && newState.scene_num !== null)
+    let hasTestNum = (newState.test_num !== undefined && newState.test_num !== null)
 
     // TODO: Fix comments for eval 3
     return <div>
@@ -65,8 +74,8 @@ const AnalysisUI = ({newState, updateHandler}) => {
 
             <div className="layout-board">
                 { (newState.perf !== undefined && newState.perf !== null) && <Results value={newState}/>}
-                { (!isEval3) && hasTestType && hasSceneNum && <Scenes value={newState}/> }
-                { isEval3 && hasCatType && hasSceneNum && <ScenesEval3 value={newState}/> }
+                { (!isEval3) && hasTestType && hasTestNum && <Scenes value={newState}/> }
+                { isEval3 && hasCatType && hasTestNum && <ScenesEval3 value={newState}/> }
                 { newState.showComments && (!isEval3) && <CommentsComponent state={newState}/> }
             </div>
         </div>
@@ -100,8 +109,12 @@ function Login({newState, userLoginHandler}) {
                 analysisString += "&category_type=" + newState.category_type;
             } 
 
-            if(newState.scene_num) {
-                analysisString += "&scene_num=" + newState.scene_num;
+            if(newState.test_num) {
+                analysisString += "&test_num=" + newState.test_num;
+            } 
+
+            if(newState.scene) {
+                analysisString += "&scene=" + newState.scene;
             } 
 
             history.push(analysisString);
@@ -134,7 +147,8 @@ export class App extends React.Component {
         this.state.showComments = (process.env.REACT_APP_COMMENTS_ON.toLowerCase() === 'true' || process.env.REACT_APP_COMMENTS_ON === '1');
         this.state.category_type = null;
         this.state.test_type = null;
-        this.state.scene_num = null;
+        this.state.test_num = null;
+        this.state.scene = null;
     
         this.logout = this.logout.bind(this);
         this.userLoginHandler = this.userLoginHandler.bind(this);
@@ -183,15 +197,19 @@ export class App extends React.Component {
         return this.state['category_type'] !== null && this.state['category_type'] !== undefined;
     }
 
+    doesStateHaveTestNum() {
+        return this.state['test_num'] !== null && this.state['test_num'] !== undefined;
+    }
+
     doesStateHaveSceneNum() {
-        return this.state['scene_num'] !== null && this.state['scene_num'] !== undefined;
+        return this.state['scene'] !== null && this.state['scene'] !== undefined;
     }
 
     updateHandler(key, item) {
         if(key === 'test_type' && this.doesStateHaveCategoryType()) {
-            this.setState({ [key]: item, category_type: null, scene_num: null});
+            this.setState({ [key]: item, category_type: null, test_num: null, scene: null});
         } else if(key === 'category_type' && this.doesStateHaveTestType()) {
-            this.setState({ [key]: item, test_type: null, scene_num: null});
+            this.setState({ [key]: item, test_type: null, test_num: null, scene: null});
         } else {
             this.setState({ [key]: item });
         }
@@ -209,8 +227,12 @@ export class App extends React.Component {
                 analysisPath += "&category_type=" + this.state['category_type'];
             }
 
+            if(this.doesStateHaveTestNum()) {
+                analysisPath += "&test_num=" + this.state['test_num'] ;
+            }
+
             if(this.doesStateHaveSceneNum()) {
-                analysisPath += "&scene_num=" + this.state['scene_num'] ;
+                analysisPath += "&scene=" + this.state['scene'] ;
             }
         }
 

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -182,10 +182,10 @@ class QueryResultsTable extends React.Component {
     
     getAnalysisPageURL = (item) => {
         if(item.scene.test_type && item.scene.scene_num) {
-            return "/analysis?eval=" + item.eval + "&test_type=" + item.scene.test_type + "&scene_num=" + item.scene.scene_num;
+            return "/analysis?eval=" + item.eval + "&test_type=" + item.scene.test_type + "&test_num=" + item.scene.scene_num;
         } else {
             // Eval 3 - use category_type & scene_part_num instead of scene_num
-            return "/analysis?eval=" + item.eval + "&category_type=" + item.category_type + "&scene_num=" + item.scene_part_num;
+            return "/analysis?eval=" + item.eval + "&category_type=" + item.category_type + "&test_num=" + item.scene_part_num;
         }
     }
 

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -182,10 +182,10 @@ class QueryResultsTable extends React.Component {
     
     getAnalysisPageURL = (item) => {
         if(item.scene.test_type && item.scene.scene_num) {
-            return "/analysis?eval=eval2_history&test_type=" + item.scene.test_type + "&scene_num=" + item.scene.scene_num;
+            return "/analysis?eval=" + item.eval + "&test_type=" + item.scene.test_type + "&scene_num=" + item.scene.scene_num;
         } else {
             // Eval 3 - use category_type & scene_part_num instead of scene_num
-            return "/analysis?eval=Evaluation%203%20Results&category_type=" + item.category_type + "&scene_num=" + item.scene_part_num;
+            return "/analysis?eval=" + item.eval + "&category_type=" + item.category_type + "&scene_num=" + item.scene_part_num;
         }
     }
 

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -184,7 +184,7 @@ class QueryResultsTable extends React.Component {
         if(item.scene.test_type && item.scene.scene_num) {
             return "/analysis?eval=" + item.eval + "&test_type=" + item.scene.test_type + "&test_num=" + item.scene.scene_num + "&scene=" + item.scene_part_num;
         } else {
-            // Eval 3 - use category_type & scene_part_num instead of scene_num
+            // Eval 3 - use category_type, swap scene_part_num and scene_num (TODO: fix in ingest)
             return "/analysis?eval=" + item.eval + "&category_type=" + item.category_type + "&test_num=" + item.scene_part_num + "&scene=" + item.scene_num;
         }
     }

--- a/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/queryResultsTable.jsx
@@ -182,10 +182,10 @@ class QueryResultsTable extends React.Component {
     
     getAnalysisPageURL = (item) => {
         if(item.scene.test_type && item.scene.scene_num) {
-            return "/analysis?eval=" + item.eval + "&test_type=" + item.scene.test_type + "&test_num=" + item.scene.scene_num;
+            return "/analysis?eval=" + item.eval + "&test_type=" + item.scene.test_type + "&test_num=" + item.scene.scene_num + "&scene=" + item.scene_part_num;
         } else {
             // Eval 3 - use category_type & scene_part_num instead of scene_num
-            return "/analysis?eval=" + item.eval + "&category_type=" + item.category_type + "&test_num=" + item.scene_part_num;
+            return "/analysis?eval=" + item.eval + "&category_type=" + item.category_type + "&test_num=" + item.scene_part_num + "&scene=" + item.scene_num;
         }
     }
 

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenes.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenes.jsx
@@ -66,7 +66,7 @@ class Scenes extends React.Component {
             flagRemove: false,
             flagInterest: false,
             testType: props.value.test_type,
-            sceneNum: props.value.scene_num
+            sceneNum: props.value.test_num
         };
     }
 
@@ -224,7 +224,7 @@ class Scenes extends React.Component {
         return (
             <Query query={mcs_history} variables={
                 {"testType": this.props.value.test_type, 
-                "sceneNum": this.props.value.scene_num
+                "sceneNum": this.props.value.test_num
                 }}>
             {
                 ({ loading, error, data }) => {
@@ -246,7 +246,7 @@ class Scenes extends React.Component {
                         return (
                             <Query query={mcs_scene} variables={
                                 {"testType": this.props.value.test_type, 
-                                "sceneNum": this.props.value.scene_num
+                                "sceneNum": this.props.value.test_num
                                 }}>
                             {
                                 ({ loading, error, data }) => {
@@ -271,7 +271,7 @@ class Scenes extends React.Component {
                                                                 <div className="movie-text"><b>Scene 3:</b>&nbsp;&nbsp;{scenesInOrder[2].answer.choice}</div>
                                                             </div>
                                                             <div className="movie-center">
-                                                                <video src={constantsObject["moviesBucket"] + this.props.value.test_type + "-" + this.props.value.scene_num + constantsObject["movieExtension"]} width="600" height="400" controls="controls" autoPlay={false} />
+                                                                <video src={constantsObject["moviesBucket"] + this.props.value.test_type + "-" + this.props.value.test_num + constantsObject["movieExtension"]} width="600" height="400" controls="controls" autoPlay={false} />
                                                             </div>
                                                             <div className="movie-left-right">
                                                                 <div className="movie-text"><b>Scene 2:</b>&nbsp;&nbsp;{scenesInOrder[1].answer.choice}</div>
@@ -325,7 +325,7 @@ class Scenes extends React.Component {
                                                     { (scenesByPerformer && scenesByPerformer[this.state.currentPerformer] && scenesByPerformer[this.state.currentPerformer][0]["category"] === "interactive") && 
                                                         <div className="movie-steps-holder">
                                                             <div className="interactive-movie-holder">
-                                                                <video id="interactiveMoviePlayer" src={constantsObject["interactiveMoviesBucket"] + constantsObject["performerPrefixMapping"][this.state.currentPerformer] + this.props.value.test_type + "-" + this.props.value.scene_num + "-" + (this.state.currentSceneNum+1) + constantsObject["movieExtension"]} width="500" height="350" controls="controls" autoPlay={false} onTimeUpdate={this.highlightStep}/>
+                                                                <video id="interactiveMoviePlayer" src={constantsObject["interactiveMoviesBucket"] + constantsObject["performerPrefixMapping"][this.state.currentPerformer] + this.props.value.test_type + "-" + this.props.value.test_num + "-" + (this.state.currentSceneNum+1) + constantsObject["movieExtension"]} width="500" height="350" controls="controls" autoPlay={false} onTimeUpdate={this.highlightStep}/>
                                                             </div>
                                                             <div className="steps-holder">
                                                                 <h5>Performer Steps:</h5>
@@ -339,7 +339,7 @@ class Scenes extends React.Component {
                                                                 </div>
                                                             </div>
                                                             <div className="top-down-holder">
-                                                                <video id="interactiveMoviePlayer" src={constantsObject["topDownMoviesBucket"] + constantsObject["performerPrefixMapping"][this.state.currentPerformer] + this.props.value.test_type + "-" + this.props.value.scene_num + "-" + (this.state.currentSceneNum+1) + constantsObject["movieExtension"]} width="500" height="350" controls="controls" autoPlay={false}/>
+                                                                <video id="interactiveMoviePlayer" src={constantsObject["topDownMoviesBucket"] + constantsObject["performerPrefixMapping"][this.state.currentPerformer] + this.props.value.test_type + "-" + this.props.value.test_num + "-" + (this.state.currentSceneNum+1) + constantsObject["movieExtension"]} width="500" height="350" controls="controls" autoPlay={false}/>
                                                             </div>
                                                         </div> 
                                                     }

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenes.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenes.jsx
@@ -61,12 +61,12 @@ class Scenes extends React.Component {
         this.state = {
             currentPerformerKey: 0,
             currentPerformer: props.value.performer !== undefined ? props.value.performer : "",
-            currentSceneNum: props.value.scene_part_num !== undefined ? parseInt(props.value.scene_part_num) - 1 : 0,
+            currentSceneNum: (props.value.scene !== undefined && props.value.scene !== null) ? parseInt(props.value.scene) - 1 : 0,
             currentObjectNum: 0,
             flagRemove: false,
             flagInterest: false,
             testType: props.value.test_type,
-            sceneNum: props.value.test_num
+            testNum: props.value.test_num
         };
     }
 
@@ -90,7 +90,29 @@ class Scenes extends React.Component {
     }
 
     changeScene = (sceneNum) => {
-        this.setState({ currentSceneNum: sceneNum});
+        if(this.state.currentSceneNum !== sceneNum) {
+            this.setState({ currentSceneNum: sceneNum});
+            let pathname = this.props.value.history.location.pathname;
+            let searchString = this.props.value.history.location.search;
+    
+            let sceneStringIndex = searchString.indexOf("&scene=");
+            let sceneToUpdate = "&scene=" + parseInt(sceneNum + 1);
+    
+            if(sceneStringIndex > -1) {
+                let newSearchString = searchString.substring(0, sceneStringIndex);
+                this.props.value.history.push({
+                    pathname: pathname,
+                    search: newSearchString + sceneToUpdate
+                });
+            } else {
+                this.props.value.history.push({
+                    pathname: pathname,
+                    search: searchString + sceneToUpdate
+                });
+            }
+    
+            this.props.updateHandler("scene", parseInt(sceneNum + 1));
+        }
     }
 
     changeObjectDisplay = (objectKey) => {
@@ -225,7 +247,8 @@ class Scenes extends React.Component {
             <Query query={mcs_history} variables={
                 {"testType": this.props.value.test_type, 
                 "sceneNum": this.props.value.test_num
-                }}>
+                }}
+                onCompleted={() => {if(this.props.value.scene === null) { this.changeScene(0);}}}>
             {
                 ({ loading, error, data }) => {
                     if (loading) return <div>Loading ...</div> 
@@ -331,7 +354,8 @@ class Scenes extends React.Component {
                                                                 <h5>Performer Steps:</h5>
                                                                 <div className="steps-container">
                                                                         <div id="stepHolder0" className="step-div step-highlight" onClick={() => this.goToVideoLocation(0)}>0: Starting Position</div>
-                                                                    {scenesByPerformer[this.state.currentPerformer][this.state.currentSceneNum].steps.map((stepObject, key) => 
+                                                                    {scenesByPerformer[this.state.currentPerformer][this.state.currentSceneNum] !== undefined &&
+                                                                     scenesByPerformer[this.state.currentPerformer][this.state.currentSceneNum].steps.map((stepObject, key) => 
                                                                         <div key={"step_div_" + key} id={"stepHolder" + (key+1)} className="step-div" onClick={() => this.goToVideoLocation(key+1)}>
                                                                             {stepObject.stepNumber + ": " + stepObject.action + " (" + this.convertValueToString(stepObject.args) + ") - " + stepObject.output.return_status}
                                                                         </div>

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenes.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenes.jsx
@@ -367,38 +367,44 @@ class Scenes extends React.Component {
                                                             </div>
                                                         </div> 
                                                     }
-                                                <div className="scene-table-div">
-                                                    <table>
-                                                        <tbody>
-                                                            {Object.keys(scenesInOrder[this.state.currentSceneNum]).map((objectKey, key) => 
-                                                                this.checkSceneObjectKey(scenesInOrder[this.state.currentSceneNum], objectKey, key))}
-                                                        </tbody>
-                                                    </table>
-                                                    <div className="objects_scenes_header">
-                                                        <h5>Objects in Scene</h5>
-                                                    </div>
-                                                    <div className="object-nav">
-                                                        <ul className="nav nav-tabs">
-                                                            {scenesInOrder[this.state.currentSceneNum].objects.map((sceneObject, key) => 
-                                                                <li className="nav-item" key={'object_tab_' + key}>
-                                                                    <button id={'object_button_' + key} className={key === 0 ? 'nav-link active' : 'nav-link'} onClick={() => this.changeObjectDisplay(key)}>{this.findObjectTabName(sceneObject)}</button>
-                                                                </li>
-                                                            )}
-                                                        </ul>
-                                                    </div>
-                                                    <div className="object-contents">
+                                                {scenesInOrder && this.state.currentSceneNum < scenesInOrder.length && scenesInOrder[this.state.currentSceneNum] &&
+                                                    <div className="scene-table-div">
                                                         <table>
                                                             <tbody>
-                                                                {Object.keys(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum]).map((objectKey, key) => 
-                                                                    <tr key={'object_tab_' + key}>
-                                                                        <td className="bold-label">{objectKey}:</td>
-                                                                        <td className="scene-text">{this.convertValueToString(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum][objectKey])}</td>
-                                                                    </tr>
-                                                                )}
+                                                                {Object.keys(scenesInOrder[this.state.currentSceneNum]).map((objectKey, key) => 
+                                                                    this.checkSceneObjectKey(scenesInOrder[this.state.currentSceneNum], objectKey, key))}
                                                             </tbody>
                                                         </table>
-                                                    </div>        
-                                                </div>
+                                                        {scenesInOrder[this.state.currentSceneNum].objects && scenesInOrder[this.state.currentSceneNum].objects.length > 0 &&
+                                                            <>
+                                                                <div className="objects_scenes_header">
+                                                                    <h5>Objects in Scene</h5>
+                                                                </div>
+                                                                <div className="object-nav">
+                                                                    <ul className="nav nav-tabs">
+                                                                        {scenesInOrder[this.state.currentSceneNum].objects.map((sceneObject, key) => 
+                                                                            <li className="nav-item" key={'object_tab_' + key}>
+                                                                                <button id={'object_button_' + key} className={key === 0 ? 'nav-link active' : 'nav-link'} onClick={() => this.changeObjectDisplay(key)}>{this.findObjectTabName(sceneObject)}</button>
+                                                                            </li>
+                                                                        )}
+                                                                    </ul>
+                                                                </div>
+                                                                <div className="object-contents">
+                                                                    <table>
+                                                                        <tbody>
+                                                                            {Object.keys(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum]).map((objectKey, key) => 
+                                                                                <tr key={'object_tab_' + key}>
+                                                                                    <td className="bold-label">{objectKey}:</td>
+                                                                                    <td className="scene-text">{this.convertValueToString(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum][objectKey])}</td>
+                                                                                </tr>
+                                                                            )}
+                                                                        </tbody>
+                                                                    </table>
+                                                                </div> 
+                                                            </>
+                                                        }       
+                                                    </div>
+                                                }
                                             </div>
                                         )
                                     }  else {

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -670,42 +670,44 @@ class ScenesEval3 extends React.Component {
                                                             </div>} 
                                                         </div>
                                                     }
-                                                <div className="scene-table-div">
-                                                    <table>
-                                                        <tbody>
-                                                            {scenesInOrder && scenesInOrder[this.state.currentSceneNum] && Object.keys(scenesInOrder[this.state.currentSceneNum]).map((objectKey, key) => 
-                                                                this.checkSceneObjectKey(scenesInOrder[this.state.currentSceneNum], objectKey, key))}
-                                                        </tbody>
-                                                    </table>
-                                                    {scenesInOrder[this.state.currentSceneNum].objects.length > 0 &&
-                                                        <>
-                                                            <div className="objects_scenes_header">
-                                                                <h5>Objects in Scene</h5>
-                                                            </div>
-                                                            <div className="object-nav">
-                                                                <ul className="nav nav-tabs">
-                                                                    {scenesInOrder && scenesInOrder[this.state.currentSceneNum] && scenesInOrder[this.state.currentSceneNum].objects.map((sceneObject, key) => 
-                                                                        <li className="nav-item" key={'object_tab_' + key}>
-                                                                            <button id={'object_button_' + key} className={key === 0 ? 'nav-link active' : 'nav-link'} onClick={() => this.changeObjectDisplay(key)}>{this.findObjectTabName(sceneObject)}</button>
-                                                                        </li>
-                                                                    )}
-                                                                </ul>
-                                                            </div>
-                                                            <div className="object-contents">
-                                                                <table>
-                                                                    <tbody>
-                                                                        {scenesInOrder && scenesInOrder[this.state.currentSceneNum] && Object.keys(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum]).map((objectKey, key) => 
-                                                                            <tr key={'object_tab_' + key}>
-                                                                                <td className="bold-label">{objectKey}:</td>
-                                                                                <td className="scene-text">{this.convertValueToString(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum][objectKey])}</td>
-                                                                            </tr>
+                                                {scenesInOrder && this.state.currentSceneNum < scenesInOrder.length && scenesInOrder[this.state.currentSceneNum] &&
+                                                    <div className="scene-table-div">
+                                                        <table>
+                                                            <tbody>
+                                                                {Object.keys(scenesInOrder[this.state.currentSceneNum]).map((objectKey, key) => 
+                                                                    this.checkSceneObjectKey(scenesInOrder[this.state.currentSceneNum], objectKey, key))}
+                                                            </tbody>
+                                                        </table>
+                                                        {scenesInOrder[this.state.currentSceneNum].objects && scenesInOrder[this.state.currentSceneNum].objects.length > 0 &&
+                                                            <>
+                                                                <div className="objects_scenes_header">
+                                                                    <h5>Objects in Scene</h5>
+                                                                </div>
+                                                                <div className="object-nav">
+                                                                    <ul className="nav nav-tabs">
+                                                                        {scenesInOrder[this.state.currentSceneNum].objects.map((sceneObject, key) => 
+                                                                            <li className="nav-item" key={'object_tab_' + key}>
+                                                                                <button id={'object_button_' + key} className={key === 0 ? 'nav-link active' : 'nav-link'} onClick={() => this.changeObjectDisplay(key)}>{this.findObjectTabName(sceneObject)}</button>
+                                                                            </li>
                                                                         )}
-                                                                    </tbody>
-                                                                </table>
-                                                            </div> 
-                                                        </>   
-                                                    }    
-                                                </div>
+                                                                    </ul>
+                                                                </div>
+                                                                <div className="object-contents">
+                                                                    <table>
+                                                                        <tbody>
+                                                                            {Object.keys(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum]).map((objectKey, key) => 
+                                                                                <tr key={'object_tab_' + key}>
+                                                                                    <td className="bold-label">{objectKey}:</td>
+                                                                                    <td className="scene-text">{this.convertValueToString(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum][objectKey])}</td>
+                                                                                </tr>
+                                                                            )}
+                                                                        </tbody>
+                                                                    </table>
+                                                                </div> 
+                                                            </>   
+                                                        }    
+                                                    </div>
+                                                }
                                             </div>
                                         )
                                     }  else {

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -118,7 +118,6 @@ class ScenesEval3 extends React.Component {
             currentMetadataLevel: props.value.metadata_lvl !== undefined ? props.value.metadata_lvl : "",
             currentSceneNum: (props.value.scene !== undefined && props.value.scene !== null) ? parseInt(props.value.scene) - 1 : 0,
             currentObjectNum: 0,
-            // evalName
             //flagRemove: false,
             //flagInterest: false,
             testType: props.value.test_type,

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -123,7 +123,7 @@ class ScenesEval3 extends React.Component {
             //flagInterest: false,
             testType: props.value.test_type,
             categoryType: props.value.category_type,
-            sceneNum: props.value.scene_num,
+            sceneNum: props.value.test_num,
             sortBy: "",
             sortOrder: "asc"
         };
@@ -401,7 +401,7 @@ class ScenesEval3 extends React.Component {
                 {    
                     "queryObject":  this.getSceneHistoryQueryObject(
                         this.props.value.category_type,
-                        this.props.value.scene_num
+                        this.props.value.test_num
                     ), 
                     "projectionObject": projectionObject
                 }}>
@@ -443,7 +443,7 @@ class ScenesEval3 extends React.Component {
                         return (
                             <Query query={mcs_scene} variables={
                                 {"sceneName": sceneNamePrefix, 
-                                "sceneNum": parseInt(this.props.value.scene_num)
+                                "sceneNum": parseInt(this.props.value.test_num)
                                 }}>
                             {
                                 ({ loading, error, data }) => {

--- a/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
+++ b/mcs_docker_setup/analysis-ui/src/components/App/scenesEval3.jsx
@@ -6,7 +6,6 @@ import $ from 'jquery';
 //import FlagCheckboxMutation from './flagCheckboxMutation';
 import {EvalConstants} from './evalConstants';
 import Accordion from 'react-bootstrap/Accordion';
-import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -117,13 +116,14 @@ class ScenesEval3 extends React.Component {
         this.state = {
             currentPerformer: props.value.performer !== undefined ? props.value.performer : "",
             currentMetadataLevel: props.value.metadata_lvl !== undefined ? props.value.metadata_lvl : "",
-            currentSceneNum: props.value.scene_part_num !== undefined ? parseInt(props.value.scene_part_num) - 1 : 0,
+            currentSceneNum: (props.value.scene !== undefined && props.value.scene !== null) ? parseInt(props.value.scene) - 1 : 0,
             currentObjectNum: 0,
+            // evalName
             //flagRemove: false,
             //flagInterest: false,
             testType: props.value.test_type,
             categoryType: props.value.category_type,
-            sceneNum: props.value.test_num,
+            testNum: props.value.test_num,
             sortBy: "",
             sortOrder: "asc"
         };
@@ -158,7 +158,28 @@ class ScenesEval3 extends React.Component {
     }
 
     changeScene = (sceneNum) => {
-        this.setState({ currentSceneNum: sceneNum});
+        if(this.state.currentSceneNum !== sceneNum) {
+            this.setState({ currentSceneNum: sceneNum});
+            let pathname = this.props.value.history.location.pathname;
+            let searchString = this.props.value.history.location.search;
+    
+            let sceneStringIndex = searchString.indexOf("&scene=");
+            let sceneToUpdate = "&scene=" + parseInt(sceneNum + 1);
+    
+            if(sceneStringIndex > -1) {
+                let newSearchString = searchString.substring(0, sceneStringIndex);
+                this.props.value.history.push({
+                    pathname: pathname,
+                    search: newSearchString + sceneToUpdate
+                });
+            } else {
+                this.props.value.history.push({
+                    pathname: pathname,
+                    search: searchString + sceneToUpdate
+                });
+            }
+            this.props.updateHandler("scene", parseInt(sceneNum + 1));
+        }
     }
 
     changeObjectDisplay = (objectKey) => {
@@ -404,7 +425,8 @@ class ScenesEval3 extends React.Component {
                         this.props.value.test_num
                     ), 
                     "projectionObject": projectionObject
-                }}>
+                }}
+                onCompleted={() => {if(this.props.value.scene === null) { this.changeScene(0);}}}>
             {
                 ({ loading, error, data }) => {
                     if (loading) return <div>Loading ...</div> 
@@ -456,7 +478,6 @@ class ScenesEval3 extends React.Component {
                                     this.initializeStepView();
 
                                     if(scenesInOrder.length > 0) {
-
                                         if(scenesInOrder.length - 1 < this.state.currentSceneNum) {
                                             this.changeScene(0);
                                         }

--- a/mcs_docker_setup/node-graphql/server.fieldMappings.js
+++ b/mcs_docker_setup/node-graphql/server.fieldMappings.js
@@ -27,7 +27,6 @@ const historyExcludeFields = [
 
 const historyExcludeFieldsTable = [
     "_id",
-    "eval",
     "flags.interest",
     "flags.remove",
     "steps.args.amount",


### PR DESCRIPTION
- Eval name is no longer hardcoded from queryResultsTable
- Corrected scene_num parameter to "test_num" in URL and added "scene" parameter to allow for selecting a particular scene via links

This is still a bit goofy because:
1.) The scene_num fields still need to be fixed in ingest (I created another ticket for that somewhere and I thought it was safer not to try to do this all at once)
2.) The way people want to select and view different tests + scenes/manage that state will probably factor into some analysis UI page redesign at some point since it is currently spread around about 3 or 4 components right now, which isn’t ideal IMO.