### PR TITLE
MCS-568 

### DIFF
--- a/analysis-ui/src/components/Analysis/scenesEval3.jsx
+++ b/analysis-ui/src/components/Analysis/scenesEval3.jsx
@@ -124,7 +124,8 @@ class ScenesEval3 extends React.Component {
             categoryType: props.value.category_type,
             testNum: props.value.test_num,
             sortBy: "",
-            sortOrder: "asc"
+            sortOrder: "asc",
+            showInternalState: false
         };
     }
 
@@ -355,6 +356,21 @@ class ScenesEval3 extends React.Component {
     checkIfScenesExist = (scenesByPerformer) =>{
         return scenesByPerformer !== undefined && scenesByPerformer[this.state.currentMetadataLevel] !== undefined
             && scenesByPerformer[this.state.currentMetadataLevel][this.state.currentPerformer] !== undefined;
+    }
+
+    toggleShowInternalState = (newValue) => {
+        this.setState({
+            showInternalState: newValue
+        });
+    }
+
+    showInternalStatePreview = (stepObj) => {
+        if(!_.isEmpty(stepObj.internal_state)) {
+            return JSON.stringify(stepObj.internal_state).substring(0, 20) + '...';
+
+        } else {
+            return JSON.stringify(stepObj.internal_state);
+        }
     }
 
     getPrettyMetadataLabel = (metadata) => {
@@ -605,6 +621,13 @@ class ScenesEval3 extends React.Component {
                                                                                         <th>Classification</th>
                                                                                         <th>Confidence</th>
                                                                                         <th>Violations ((x,y) list)</th>
+                                                                                        {this.props.value.eval !== "Evaluation 3 Results" &&
+                                                                                            <th>Internal State
+                                                                                                <br/>
+                                                                                                <span className={this.state.showInternalState ? "internal-state-toggle" : "display-none"} onClick={() => this.toggleShowInternalState(false)}>(Click to Collapse)</span>
+                                                                                                <span className={this.state.showInternalState ? "display-none" : "internal-state-toggle"} onClick={() => this.toggleShowInternalState(true)}>(Click to Expand)</span>
+                                                                                            </th>
+                                                                                        }
                                                                                     </tr>
                                                                                 </thead>
                                                                                 <tbody>
@@ -621,6 +644,16 @@ class ScenesEval3 extends React.Component {
                                                                                                         this.convertXYArrayToString(stepObj.violations_xy_list)                                                                     
                                                                                                 }
                                                                                             </td>
+                                                                                            {this.props.value.eval !== "Evaluation 3 Results" && 
+                                                                                                <td className="internal-state-cell">
+                                                                                                    <span className={this.state.showInternalState ? "" : "display-none"}>
+                                                                                                        {JSON.stringify(stepObj.internal_state)}
+                                                                                                    </span>
+                                                                                                    <span className={this.state.showInternalState ? "display-none" : ""}>
+                                                                                                        {this.showInternalStatePreview(stepObj)}
+                                                                                                    </span>
+                                                                                                </td>
+                                                                                            }
                                                                                         </tr>
                                                                                     )}
                                                                                 </tbody>

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -929,3 +929,12 @@ ol, ul {
 .classification-by-step-header {
     cursor: pointer;
 }
+
+.internal-state-toggle {
+    color: #007bff;
+    cursor: pointer;
+}
+.internal-state-cell {
+    max-width: 500px;
+    word-wrap: break-word;
+}

--- a/node-graphql/server.fieldMappings.js
+++ b/node-graphql/server.fieldMappings.js
@@ -22,6 +22,7 @@ const historyExcludeFields = [
     "filename",
     "fullFilename",
     "steps.confidence",
+    "steps.internal_state",
     "steps.classification"
 ];
 
@@ -49,6 +50,7 @@ const historyExcludeFieldsTable = [
     "fullFilename",
     "steps.confidence",
     "steps.classification",
+    "steps.internal_state",
     "steps.action",
     "steps.output.return_status",
     "steps",


### PR DESCRIPTION
Adding internal_state placeholder to analysis UI table until eval 3.5 redesigns are implemented (I'm sure those have addressed/fixed how messy the table can get). 

Goes with ingest PR here: https://github.com/NextCenturyCorporation/mcs-ingest/pull/6