### PR TITLE
MCS-590

### DIFF
--- a/analysis-ui/src/components/Analysis/evalConstants.jsx
+++ b/analysis-ui/src/components/Analysis/evalConstants.jsx
@@ -6,6 +6,7 @@ const Eval2 = {
     sceneBucket: "https://evaluation-images.s3.amazonaws.com/eval-2-scenes/",
     sceneExtension: "-debug.json",
 
+    // note that this performerPrefixMapping is only used on the Eval 2 Results Page
     performerPrefixMapping: {
         "IBM-MIT-Harvard-Stanford": "mitibm_",
         "OPICS (OSU, UU, NYU)": "opics_",
@@ -21,15 +22,20 @@ const Eval3 = {
     movieExtension: ".mp4",
     sceneBucket: "https://evaluation-images.s3.amazonaws.com/eval-3-scenes/",
     sceneExtension: "_debug.json",
-
-    performerPrefixMapping: {
-        "IBM-MIT-Harvard-Stanford": "mit_",
-        "OPICS (OSU, UU, NYU)": "opics_",
-        "MESS-UCBerkeley": "mess_",
-    }
 }
 
+const Eval3_5 = {
+    moviesBucket: "https://evaluation-images.s3.amazonaws.com/eval-3.5",
+    interactiveMoviesBucket: "https://evaluation-images.s3.amazonaws.com/eval-3.5/",
+    topDownMoviesBucket: "https://evaluation-images.s3.amazonaws.com/eval-3.5/",
+    movieExtension: ".mp4",
+    sceneBucket: "https://evaluation-images.s3.amazonaws.com/eval-scenes-3.5/", 
+    sceneExtension: "_debug.json",
+}
+
+// TODO: MCS-589: move to ingest/store in mongo
 export const EvalConstants = {
-    "Eval2": Eval2, 
-    "Eval3": Eval3
+    "Evaluation 2 Results": Eval2, 
+    "Evaluation 3 Results": Eval3,
+    "Evaluation 3.5 Results": Eval3_5
 }

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -267,7 +267,7 @@ class Scenes extends React.Component {
                     let performerList = Object.keys(scenesByPerformer);
                     this.setInitialPerformer(performerList[0], evals[0]);
 
-                    setConstants("Eval2");
+                    setConstants(this.props.value.eval);
 
                     if(performerList.length > 0) {
                         return (

--- a/analysis-ui/src/components/Analysis/scenesEval3.jsx
+++ b/analysis-ui/src/components/Analysis/scenesEval3.jsx
@@ -306,11 +306,11 @@ class ScenesEval3 extends React.Component {
         return name.substring(0, name.indexOf('_')) + '*';
     }
 
-    getSceneHistoryQueryObject = (categoryType, testNum) => {
+    getSceneHistoryQueryObject = (evalName, categoryType, testNum) => {
         return [
             {
-                fieldType: "mcs_history.Evaluation 3 Results",
-                fieldTypeLabel: "Evaluation 3 Results",
+                fieldType: "mcs_history." + evalName,
+                fieldTypeLabel: evalName,
                 fieldName: "category_type",
                 fieldNameLabel: "Test Type",
                 fieldValue1: categoryType,
@@ -319,8 +319,8 @@ class ScenesEval3 extends React.Component {
                 collectionDropdownToggle: 1
             },
             {
-                fieldType: "mcs_history.Evaluation 3 Results",
-                fieldTypeLabel: "Evaluation 3 Results",
+                fieldType: "mcs_history." + evalName,
+                fieldTypeLabel: evalName,
                 fieldName: "test_num",
                 fieldNameLabel: "Test Number",
                 fieldValue1: parseInt(testNum),
@@ -421,6 +421,7 @@ class ScenesEval3 extends React.Component {
             <Query query={create_complex_query} variables={
                 {    
                     "queryObject":  this.getSceneHistoryQueryObject(
+                        this.props.value.eval,
                         this.props.value.category_type,
                         this.props.value.test_num
                     ), 
@@ -457,7 +458,7 @@ class ScenesEval3 extends React.Component {
 
                     this.setInitialPerformer(performerList[0], evals[0]);
                     
-                    setConstants("Eval3");
+                    setConstants(this.props.value.eval);
 
                     let sceneNamePrefix = null;
                     

--- a/analysis-ui/src/components/Analysis/scenesEval3.jsx
+++ b/analysis-ui/src/components/Analysis/scenesEval3.jsx
@@ -484,7 +484,7 @@ class ScenesEval3 extends React.Component {
 
                                     if(scenesInOrder.length > 0) {
                                         if(scenesInOrder.length < this.state.currentSceneNum) {
-                                            this.changeScene(scenesInOrder[0]["scene_num"].toString());
+                                            this.changeScene(scenesInOrder[0]["scene_num"]);
                                         }
 
                                         if(metadataList.indexOf(this.state.currentMetadataLevel) === -1) {             


### PR DESCRIPTION
Fixing bug with selecting scenes from analysis page table when the table is sorted by something other than the default (videos for interactive/passive step by step info wasn't always lining up). 

Also tacked on a few things for Eval 3.5.