### PR TITLE
MCS-517 - [Analysis UI Page] Move scene info/objects in scene details to a modal

### DIFF
--- a/analysis-ui/src/components/Analysis/displayTextUtils.js
+++ b/analysis-ui/src/components/Analysis/displayTextUtils.js
@@ -1,0 +1,49 @@
+function convertArrayToString(arrayToConvert) {
+    let newStr = "";
+    for(let i=0; i < arrayToConvert.length; i++) {
+        newStr = newStr + convertValueToString(arrayToConvert[i]);
+
+        if(i < arrayToConvert.length -1) {
+            newStr = newStr + ", ";
+        }
+    }
+
+    return newStr;
+}
+
+function convertObjectToString(objectToConvert) {
+    let newStr = "";
+    Object.keys(objectToConvert).forEach((key, index) => {
+        newStr = newStr + key + ": " + convertValueToString(objectToConvert[key]);
+
+        if(index < Object.keys(objectToConvert).length - 1) {
+            newStr = newStr + ", ";
+        }
+    })
+
+    return newStr;
+}
+
+export function convertValueToString(valueToConvert) {
+    if(Array.isArray(valueToConvert) && valueToConvert !== null) {
+        return convertArrayToString(valueToConvert);
+    }
+
+    if(typeof valueToConvert === 'object' && valueToConvert !== null) {
+        return convertObjectToString(valueToConvert);
+    }
+
+    if(valueToConvert === true) {
+        return "true";
+    } 
+
+    if(valueToConvert === false) {
+        return "false";
+    } 
+
+    if(!isNaN(valueToConvert)) {
+        return Math.floor(valueToConvert * 100) / 100;
+    }
+
+    return valueToConvert;
+}

--- a/analysis-ui/src/components/Analysis/sceneDetails.jsx
+++ b/analysis-ui/src/components/Analysis/sceneDetails.jsx
@@ -66,8 +66,8 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
                             Scene {currentSceneNum} Details 
                         </Modal.Title>
 
-                        {currentScene !== undefined
-                            && currentScene !== null && <div className="download-scene">
+                        {currentScene !== undefined && currentScene !== null &&
+                        <div className="download-scene">
                             <a href={constantsObject["sceneBucket"] + currentScene.name + constantsObject["sceneExtension"]} download>
                                 <i className='material-icons'>get_app</i>
                                 <span className="download-scene-text">Download .JSON</span>

--- a/analysis-ui/src/components/Analysis/sceneDetails.jsx
+++ b/analysis-ui/src/components/Analysis/sceneDetails.jsx
@@ -1,0 +1,138 @@
+import React, {useState} from 'react';
+import $ from 'jquery';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button'
+import { convertValueToString } from './displayTextUtils';
+
+function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constantsObject}) {
+    
+    const [currentObjectNum, setCurrentObjectNum] = useState(0);
+
+    const closeModal = () => {
+        onHide();
+    }
+
+    const checkSceneObjectKey = (scene, objectKey, key, labelPrefix = "") => {
+        if(objectKey !== 'objects' && objectKey !== 'goal' && objectKey !== 'name') {
+            return (
+                <tr key={'scene_prop_' + key}>
+                    <td className="bold-label">{labelPrefix + objectKey}:</td>
+                    <td className="scene-text">{convertValueToString(scene[objectKey])}</td>
+                </tr>
+            );
+        } else if(objectKey === 'goal') {
+            return (
+                Object.keys(scene["goal"]).map((goalObjectKey, goalKey) => 
+                    checkSceneObjectKey(scene["goal"], goalObjectKey, goalKey, "goal."))
+            );
+        } else if(objectKey === 'name') {
+            return (
+                <tr key={'scene_prop_' + key}>
+                    <td className="bold-label">{labelPrefix + objectKey}:</td>
+                    <td className="scene-text">{convertValueToString(scene[objectKey])} (<a href={constantsObject["sceneBucket"] + scene[objectKey] + constantsObject["sceneExtension"]} download>Download Scene File</a>)</td>
+                </tr>
+            );
+        }
+    }
+
+    const findObjectTabName = (sceneObject) => {
+        if(sceneObject.shape !== undefined && sceneObject.shape !== null) {
+            return sceneObject.shape;
+        }
+
+        if(sceneObject.id.indexOf('occluder_wall')) {
+            return "occluder wall";
+        }
+
+        if(sceneObject.id.indexOf('occluder_pole')) {
+            return "occluder pole";
+        }
+
+        return sceneObject.type;
+    }
+
+    const changeObjectDisplay = (objectKey) => {
+        $('#object_button_' + currentObjectNum ).toggleClass( "active" );
+        $('#object_button_' + objectKey ).toggleClass( "active" );
+
+        setCurrentObjectNum(objectKey);
+    }
+
+    return (
+        <Modal show={show} onHide={closeModal} size="lg" aria-labelledby="contained-modal-title-vcenter" centered scrollable={true}>
+            <Modal.Header closeButton>
+                <Modal.Title>
+                    Scene {currentSceneNum} Details     
+                </Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                {currentScene !== undefined
+                    && currentScene !== null &&
+                    <div className="scene-table-div">
+                        <table>
+                            <tbody>
+                                {Object.keys(currentScene).map((objectKey, key) => 
+                                    checkSceneObjectKey(currentScene, objectKey, key))}
+                            </tbody>
+                        </table>
+                        {currentScene.objects && currentScene.objects.length > 0 &&
+                            <>
+                                <div className="objects_scenes_header">
+                                    <h5>Objects in Scene</h5>
+                                </div>
+                                <div className="object-nav">
+                                    <ul className="nav nav-tabs">
+                                        {currentScene.objects.map((sceneObject, key) => 
+                                            <li className="nav-item" key={'object_tab_' + key}>
+                                                <button id={'object_button_' + key} className={key === 0 ? 'nav-link active' : 'nav-link'} onClick={() => changeObjectDisplay(key)}>{findObjectTabName(sceneObject)}</button>
+                                            </li>
+                                        )}
+                                    </ul>
+                                </div>
+                                <div className="object-contents">
+                                    <table>
+                                        <tbody>
+                                            { Object.keys(currentScene.objects[currentObjectNum]).map((objectKey, key) => 
+                                                <tr key={'object_tab_' + key}>
+                                                    <td className="bold-label">{objectKey}:</td>
+                                                    <td className="scene-text">{convertValueToString(currentScene.objects[currentObjectNum][objectKey])}</td>
+                                                </tr>
+                                            )}
+                                        </tbody>
+                                    </table>
+                                </div> 
+                            </>   
+                        }    
+                    </div>
+                }
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="primary" onClick={closeModal}>Close Details</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+function SceneDetails ({currentSceneNum, currentScene, constantsObject}) {
+
+    const [modalShow, setModalShow] = useState(false);
+
+    return (
+        <>
+            <div className="show-details-toggle" onClick={() => setModalShow(true)}>
+                <i className='material-icons' style={{fontSize: '24px'}}>fullscreen</i>
+            </div>
+
+            <SceneDetailsModal
+                show = {modalShow}
+                onHide = {() => setModalShow(false)}
+                currentSceneNum={currentSceneNum}
+                currentScene={currentScene}
+                constantsObject={constantsObject}
+            />
+        </>
+    );
+    
+}
+
+export default SceneDetails;

--- a/analysis-ui/src/components/Analysis/sceneDetails.jsx
+++ b/analysis-ui/src/components/Analysis/sceneDetails.jsx
@@ -7,13 +7,14 @@ import { convertValueToString } from './displayTextUtils';
 function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constantsObject}) {
     
     const [currentObjectNum, setCurrentObjectNum] = useState(0);
+    const [selectedData, setSelectedData] = useState("scene_info");
 
     const closeModal = () => {
         onHide();
     }
 
     const checkSceneObjectKey = (scene, objectKey, key, labelPrefix = "") => {
-        if(objectKey !== 'objects' && objectKey !== 'goal' && objectKey !== 'name') {
+        if(objectKey !== 'objects' && objectKey !== 'goal') {
             return (
                 <tr key={'scene_prop_' + key}>
                     <td className="bold-label">{labelPrefix + objectKey}:</td>
@@ -24,13 +25,6 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
             return (
                 Object.keys(scene["goal"]).map((goalObjectKey, goalKey) => 
                     checkSceneObjectKey(scene["goal"], goalObjectKey, goalKey, "goal."))
-            );
-        } else if(objectKey === 'name') {
-            return (
-                <tr key={'scene_prop_' + key}>
-                    <td className="bold-label">{labelPrefix + objectKey}:</td>
-                    <td className="scene-text">{convertValueToString(scene[objectKey])} (<a href={constantsObject["sceneBucket"] + scene[objectKey] + constantsObject["sceneExtension"]} download>Download Scene File</a>)</td>
-                </tr>
             );
         }
     }
@@ -61,30 +55,52 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
     return (
         <Modal show={show} onHide={closeModal} size="lg" aria-labelledby="contained-modal-title-vcenter" centered scrollable={true}>
             <Modal.Header closeButton>
-                <Modal.Title>
-                    Scene {currentSceneNum} Details     
-                </Modal.Title>
+                <div className="scene-details-header">
+                    <div className="scene-title-and-download">
+                        <Modal.Title>
+                            Scene {currentSceneNum} Details 
+                        </Modal.Title>
+
+                        <div className="download-scene">
+                            <a href={constantsObject["sceneBucket"] + currentScene.name + constantsObject["sceneExtension"]} download>
+                                <i className='material-icons' style={{fontSize: '24px'}}>get_app</i>
+                                <span className="download-scene-text">Download .JSON</span>
+                            </a>
+                        </div>
+                    </div>
+
+                    <div className="scene-details-btn-group btn-group" role="group">
+                        <button className={"scene_info" === selectedData ? 'btn btn-primary active' : 'btn btn-secondary'}
+                            id='toggle_data_scene_info' key='toggle_scene_info' type="button"
+                            onClick={() => setSelectedData("scene_info")}>
+                                Scene Details
+                        </button>
+                        <button className={"scene_objects" === selectedData ? 'btn btn-primary active' : 'btn btn-secondary'}
+                            id='toggle_data_scene_objects' key='toggle_scene_objects' type="button"
+                            onClick={() => setSelectedData("scene_objects")}>
+                                Objects In Scene
+                        </button>
+                    </div>  
+                </div>
             </Modal.Header>
             <Modal.Body>
                 {currentScene !== undefined
                     && currentScene !== null &&
                     <div className="scene-table-div">
-                        <table>
+                        <table className={"scene_info" !== selectedData ? "display-none" : ""}>
                             <tbody>
                                 {Object.keys(currentScene).map((objectKey, key) => 
                                     checkSceneObjectKey(currentScene, objectKey, key))}
                             </tbody>
                         </table>
+
                         {currentScene.objects && currentScene.objects.length > 0 &&
-                            <>
-                                <div className="objects_scenes_header">
-                                    <h5>Objects in Scene</h5>
-                                </div>
+                            <div className={"scene_objects" !== selectedData ? "display-none" : ""}>
                                 <div className="object-nav">
                                     <ul className="nav nav-tabs">
                                         {currentScene.objects.map((sceneObject, key) => 
                                             <li className="nav-item" key={'object_tab_' + key}>
-                                                <button id={'object_button_' + key} className={key === 0 ? 'nav-link active' : 'nav-link'} onClick={() => changeObjectDisplay(key)}>{findObjectTabName(sceneObject)}</button>
+                                                <button id={'object_button_' + key} className={key === currentObjectNum ? 'nav-link active' : 'nav-link'} onClick={() => changeObjectDisplay(key)}>{findObjectTabName(sceneObject)}</button>
                                             </li>
                                         )}
                                     </ul>
@@ -101,7 +117,7 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
                                         </tbody>
                                     </table>
                                 </div> 
-                            </>   
+                            </div>   
                         }    
                     </div>
                 }

--- a/analysis-ui/src/components/Analysis/sceneDetails.jsx
+++ b/analysis-ui/src/components/Analysis/sceneDetails.jsx
@@ -66,12 +66,13 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
                             Scene {currentSceneNum} Details 
                         </Modal.Title>
 
-                        <div className="download-scene">
+                        {currentScene !== undefined
+                            && currentScene !== null && <div className="download-scene">
                             <a href={constantsObject["sceneBucket"] + currentScene.name + constantsObject["sceneExtension"]} download>
-                                <i className='material-icons' style={{fontSize: '24px'}}>get_app</i>
+                                <i className='material-icons'>get_app</i>
                                 <span className="download-scene-text">Download .JSON</span>
                             </a>
-                        </div>
+                        </div>}
                     </div>
 
                     <div className="scene-details-btn-group btn-group" role="group">
@@ -141,7 +142,7 @@ function SceneDetails ({currentSceneNum, currentScene, constantsObject}) {
     return (
         <>
             <div className="show-details-toggle" onClick={() => setModalShow(true)}>
-                <i className='material-icons' style={{fontSize: '24px'}}>fullscreen</i>
+                <i className='material-icons'>fullscreen</i>
             </div>
 
             <SceneDetailsModal

--- a/analysis-ui/src/components/Analysis/sceneDetails.jsx
+++ b/analysis-ui/src/components/Analysis/sceneDetails.jsx
@@ -12,6 +12,8 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
 
     const closeModal = () => {
         onHide();
+        setCurrentObjectNum(0);
+        setSelectedData("scene_info");
     }
 
     const checkSceneObjectKey = (scene, objectKey, key, labelPrefix = "") => {

--- a/analysis-ui/src/components/Analysis/sceneDetails.jsx
+++ b/analysis-ui/src/components/Analysis/sceneDetails.jsx
@@ -8,13 +8,14 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
     
     const [currentObjectNum, setCurrentObjectNum] = useState(0);
     const [selectedData, setSelectedData] = useState("scene_info");
+    const keysToIgnore = ['objects', 'goal', 'objectsInfo'];
 
     const closeModal = () => {
         onHide();
     }
 
     const checkSceneObjectKey = (scene, objectKey, key, labelPrefix = "") => {
-        if(objectKey !== 'objects' && objectKey !== 'goal') {
+        if(!keysToIgnore.includes(objectKey)) {
             return (
                 <tr key={'scene_prop_' + key}>
                     <td className="bold-label">{labelPrefix + objectKey}:</td>
@@ -34,12 +35,16 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
             return sceneObject.shape;
         }
 
-        if(sceneObject.id.indexOf('occluder_wall')) {
+        if(sceneObject.id.indexOf('occluder_wall') > -1) {
             return "occluder wall";
         }
 
-        if(sceneObject.id.indexOf('occluder_pole')) {
+        if(sceneObject.id.indexOf('occluder_pole') > -1) {
             return "occluder pole";
+        }
+
+        if(sceneObject.role !== undefined && sceneObject.role !== null) {
+            return sceneObject.role;
         }
 
         return sceneObject.type;

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -125,52 +125,6 @@ class Scenes extends React.Component {
         }
     }
 
-    changeObjectDisplay = (objectKey) => {
-        $('#object_button_' + this.state.currentObjectNum ).toggleClass( "active" );
-        $('#object_button_' + objectKey ).toggleClass( "active" );
-
-        this.setState({ currentObjectNum: objectKey});
-    }
-
-    findObjectTabName = (sceneObject) => {
-        if(sceneObject.shape !== undefined && sceneObject.shape !== null) {
-            return sceneObject.shape;
-        }
-
-        if(sceneObject.id.indexOf('occluder_wall')) {
-            return "occluder wall";
-        }
-
-        if(sceneObject.id.indexOf('occluder_pole')) {
-            return "occluder pole";
-        }
-
-        return sceneObject.type;
-    }
-
-    checkSceneObjectKey = (scene, objectKey, key, labelPrefix = "") => {
-        if(objectKey !== 'objects' && objectKey !== 'goal' && objectKey !== 'name') {
-            return (
-                <tr key={'scene_prop_' + key}>
-                    <td className="bold-label">{labelPrefix + objectKey}:</td>
-                    <td className="scene-text">{convertValueToString(scene[objectKey])}</td>
-                </tr>
-            );
-        } else if(objectKey === 'goal') {
-            return (
-                Object.keys(scene["goal"]).map((goalObjectKey, goalKey) => 
-                    this.checkSceneObjectKey(scene["goal"], goalObjectKey, goalKey, "goal."))
-            );
-        } else if(objectKey === 'name') {
-            return (
-                <tr key={'scene_prop_' + key}>
-                    <td className="bold-label">{labelPrefix + objectKey}:</td>
-                    <td className="scene-text">{convertValueToString(scene[objectKey])} (<a href={constantsObject["sceneBucket"] + scene[objectKey] + constantsObject["sceneExtension"]} download>Download Scene File</a>)</td>
-                </tr>
-            );
-        }
-    }
-
     highlightStep = (e) => {
         // First one is at 0.2 
         let currentTimeNum = Math.floor(document.getElementById("interactiveMoviePlayer").currentTime + 0.8);

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -5,6 +5,7 @@ import _ from "lodash";
 import $ from 'jquery';
 import FlagCheckboxMutation from './flagCheckboxMutation';
 import {EvalConstants} from './evalConstants';
+import { convertValueToString } from './displayTextUtils';
 
 const historyQueryName = "getEvalHistory";
 const sceneQueryName = "getEvalScene";
@@ -122,56 +123,6 @@ class Scenes extends React.Component {
         this.setState({ currentObjectNum: objectKey});
     }
 
-    convertArrayToString = (arrayToConvert) => {
-        let newStr = "";
-        for(let i=0; i < arrayToConvert.length; i++) {
-            newStr = newStr + this.convertValueToString(arrayToConvert[i]);
-
-            if(i < arrayToConvert.length -1) {
-                newStr = newStr + ", ";
-            }
-        }
-
-        return newStr;
-    }
-
-    convertObjectToString = (objectToConvert) => {
-        let newStr = "";
-        Object.keys(objectToConvert).forEach((key, index) => {
-            newStr = newStr + key + ": " + this.convertValueToString(objectToConvert[key]);
-
-            if(index < Object.keys(objectToConvert).length - 1) {
-                newStr = newStr + ", ";
-            }
-        })
-
-        return newStr;
-    }
-
-    convertValueToString = (valueToConvert) => {
-        if(Array.isArray(valueToConvert) && valueToConvert !== null) {
-            return this.convertArrayToString(valueToConvert);
-        }
-
-        if(typeof valueToConvert === 'object' && valueToConvert !== null) {
-            return this.convertObjectToString(valueToConvert);
-        }
-
-        if(valueToConvert === true) {
-            return "true";
-        } 
-
-        if(valueToConvert === false) {
-            return "false";
-        } 
-
-        if(!isNaN(valueToConvert)) {
-            return Math.floor(valueToConvert * 100) / 100;
-        }
-
-        return valueToConvert;
-    }
-
     findObjectTabName = (sceneObject) => {
         if(sceneObject.shape !== undefined && sceneObject.shape !== null) {
             return sceneObject.shape;
@@ -193,7 +144,7 @@ class Scenes extends React.Component {
             return (
                 <tr key={'scene_prop_' + key}>
                     <td className="bold-label">{labelPrefix + objectKey}:</td>
-                    <td className="scene-text">{this.convertValueToString(scene[objectKey])}</td>
+                    <td className="scene-text">{convertValueToString(scene[objectKey])}</td>
                 </tr>
             );
         } else if(objectKey === 'goal') {
@@ -205,7 +156,7 @@ class Scenes extends React.Component {
             return (
                 <tr key={'scene_prop_' + key}>
                     <td className="bold-label">{labelPrefix + objectKey}:</td>
-                    <td className="scene-text">{this.convertValueToString(scene[objectKey])} (<a href={constantsObject["sceneBucket"] + scene[objectKey] + constantsObject["sceneExtension"]} download>Download Scene File</a>)</td>
+                    <td className="scene-text">{convertValueToString(scene[objectKey])} (<a href={constantsObject["sceneBucket"] + scene[objectKey] + constantsObject["sceneExtension"]} download>Download Scene File</a>)</td>
                 </tr>
             );
         }
@@ -361,7 +312,7 @@ class Scenes extends React.Component {
                                                                     {scenesByPerformer[this.state.currentPerformer][this.state.currentSceneNum] !== undefined &&
                                                                      scenesByPerformer[this.state.currentPerformer][this.state.currentSceneNum].steps.map((stepObject, key) => 
                                                                         <div key={"step_div_" + key} id={"stepHolder" + (key+1)} className="step-div" onClick={() => this.goToVideoLocation(key+1)}>
-                                                                            {stepObject.stepNumber + ": " + stepObject.action + " (" + this.convertValueToString(stepObject.args) + ") - " + stepObject.output.return_status}
+                                                                            {stepObject.stepNumber + ": " + stepObject.action + " (" + convertValueToString(stepObject.args) + ") - " + stepObject.output.return_status}
                                                                         </div>
                                                                     )}
                                                                 </div>
@@ -399,7 +350,7 @@ class Scenes extends React.Component {
                                                                             {Object.keys(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum]).map((objectKey, key) => 
                                                                                 <tr key={'object_tab_' + key}>
                                                                                     <td className="bold-label">{objectKey}:</td>
-                                                                                    <td className="scene-text">{this.convertValueToString(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum][objectKey])}</td>
+                                                                                    <td className="scene-text">{convertValueToString(scenesInOrder[this.state.currentSceneNum].objects[this.state.currentObjectNum][objectKey])}</td>
                                                                                 </tr>
                                                                             )}
                                                                         </tbody>

--- a/analysis-ui/src/components/Analysis/scenesEval3.jsx
+++ b/analysis-ui/src/components/Analysis/scenesEval3.jsx
@@ -505,7 +505,7 @@ class ScenesEval3 extends React.Component {
                                                     </div>
                                                 }
 
-                                                {/* TODO: MCS-517 start video logic for interactive scenes */}
+                                                {/* start video logic for interactive scenes */}
                                                     { (this.checkIfScenesExist(scenesByPerformer) && this.getSceneHistoryItem(scenesByPerformer) !== undefined && this.getSceneHistoryItem(scenesByPerformer)["category"] === "interactive") &&
                                                         <div>
                                                             <div className="movie-steps-holder">
@@ -539,7 +539,7 @@ class ScenesEval3 extends React.Component {
                                                             </div>} 
                                                         </div>
                                                     }
-                                                {/* TODO: MCS-517 end video logic for interactive scenes */}
+                                                {/* end video logic for interactive scenes */}
                                             </div>
                                         )
                                     }  else {

--- a/analysis-ui/src/components/Analysis/scenesEval3.jsx
+++ b/analysis-ui/src/components/Analysis/scenesEval3.jsx
@@ -6,15 +6,16 @@ import $ from 'jquery';
 //import FlagCheckboxMutation from './flagCheckboxMutation';
 import {EvalConstants} from './evalConstants';
 import Accordion from 'react-bootstrap/Accordion';
-import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card';
-import Modal from 'react-bootstrap/Modal'
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
+import SceneDetails from './sceneDetails';
+import { convertValueToString } from './displayTextUtils';
+
 
 const historyQueryName = "createComplexQuery";
 const historyQueryResults = "results";
@@ -105,8 +106,7 @@ class ScenesEval3 extends React.Component {
             testNum: props.value.test_num,
             sortBy: "",
             sortOrder: "asc",
-            showInternalState: false,
-            showDetailsModal: false
+            showInternalState: false
         };
     }
 
@@ -163,109 +163,14 @@ class ScenesEval3 extends React.Component {
         }
     }
 
-    changeObjectDisplay = (objectKey) => {
-        $('#object_button_' + this.state.currentObjectNum ).toggleClass( "active" );
-        $('#object_button_' + objectKey ).toggleClass( "active" );
-
-        this.setState({ currentObjectNum: objectKey});
-    }
-
-    convertArrayToString = (arrayToConvert) => {
-        let newStr = "";
-        for(let i=0; i < arrayToConvert.length; i++) {
-            newStr = newStr + this.convertValueToString(arrayToConvert[i]);
-
-            if(i < arrayToConvert.length -1) {
-                newStr = newStr + ", ";
-            }
-        }
-
-        return newStr;
-    }
-
-    convertObjectToString = (objectToConvert) => {
-        let newStr = "";
-        Object.keys(objectToConvert).forEach((key, index) => {
-            newStr = newStr + key + ": " + this.convertValueToString(objectToConvert[key]);
-
-            if(index < Object.keys(objectToConvert).length - 1) {
-                newStr = newStr + ", ";
-            }
-        })
-
-        return newStr;
-    }
-
-    convertValueToString = (valueToConvert) => {
-        if(Array.isArray(valueToConvert) && valueToConvert !== null) {
-            return this.convertArrayToString(valueToConvert);
-        }
-
-        if(typeof valueToConvert === 'object' && valueToConvert !== null) {
-            return this.convertObjectToString(valueToConvert);
-        }
-
-        if(valueToConvert === true) {
-            return "true";
-        } 
-
-        if(valueToConvert === false) {
-            return "false";
-        } 
-
-        if(!isNaN(valueToConvert)) {
-            return Math.floor(valueToConvert * 100) / 100;
-        }
-
-        return valueToConvert;
-    }
 
     displayItemText(row, dataKey) {
         let item = _.get(row, dataKey);
 
         if(item !== undefined && item !== null && item !== "") {
-            return this.convertValueToString(item);
+            return convertValueToString(item);
         } else {
             return "";
-        }
-    }
-
-    findObjectTabName = (sceneObject) => {
-        if(sceneObject.shape !== undefined && sceneObject.shape !== null) {
-            return sceneObject.shape;
-        }
-
-        if(sceneObject.id.indexOf('occluder_wall')) {
-            return "occluder wall";
-        }
-
-        if(sceneObject.id.indexOf('occluder_pole')) {
-            return "occluder pole";
-        }
-
-        return sceneObject.type;
-    }
-
-    checkSceneObjectKey = (scene, objectKey, key, labelPrefix = "") => {
-        if(objectKey !== 'objects' && objectKey !== 'goal' && objectKey !== 'name') {
-            return (
-                <tr key={'scene_prop_' + key}>
-                    <td className="bold-label">{labelPrefix + objectKey}:</td>
-                    <td className="scene-text">{this.convertValueToString(scene[objectKey])}</td>
-                </tr>
-            );
-        } else if(objectKey === 'goal') {
-            return (
-                Object.keys(scene["goal"]).map((goalObjectKey, goalKey) => 
-                    this.checkSceneObjectKey(scene["goal"], goalObjectKey, goalKey, "goal."))
-            );
-        } else if(objectKey === 'name') {
-            return (
-                <tr key={'scene_prop_' + key}>
-                    <td className="bold-label">{labelPrefix + objectKey}:</td>
-                    <td className="scene-text">{this.convertValueToString(scene[objectKey])} (<a href={constantsObject["sceneBucket"] + scene[objectKey] + constantsObject["sceneExtension"]} download>Download Scene File</a>)</td>
-                </tr>
-            );
         }
     }
 
@@ -400,7 +305,7 @@ class ScenesEval3 extends React.Component {
     convertXYArrayToString = (arrayToConvert) => {
         let newStr = "";
         for(let i=0; i < arrayToConvert.length; i++) {
-            newStr = newStr + '(' + this.convertValueToString(arrayToConvert[i]) + ')';
+            newStr = newStr + '(' + convertValueToString(arrayToConvert[i]) + ')';
 
             if(i < arrayToConvert.length -1) {
                 newStr = newStr + ", ";
@@ -423,10 +328,6 @@ class ScenesEval3 extends React.Component {
     // need to subtract 1 to use as array index in scenesInOrder
     getCurrentScene = (scenesInOrder) => {
         return scenesInOrder[this.state.currentSceneNum - 1];
-    }
-
-    handleToggleDetailsModal = (showModal) => {
-        this.setState({ showDetailsModal: showModal});
     }
 
     render() {
@@ -587,68 +488,19 @@ class ScenesEval3 extends React.Component {
                                                                     </TableCell>
                                                                 ))}
                                                                     <TableCell key={"performer_score_row_" + rowKey + "_col_details"}>
-                                                                        <div className="show-details-toggle" onClick={() => this.handleToggleDetailsModal(true)}>
-                                                                            <i className='material-icons' style={{fontSize: '24px'}}>fullscreen</i>
-                                                                        </div>
+
+                                                                        <SceneDetails  
+                                                                            currentSceneNum={this.state.currentSceneNum}
+                                                                            currentScene={this.getCurrentScene(scenesInOrder)}
+                                                                            constantsObject={constantsObject}
+                                                                        />
+                                                                        
                                                                     </TableCell>
                                                             </TableRow>
                                                         )}
                                                         </TableBody>
                                                     </Table>
                                                 </div>
-
-                                                {/* TODO: MCS-517: Make scene details modal component?  */}
-                                                    <Modal show={this.state.showDetailsModal} size="lg" aria-labelledby="contained-modal-title-vcenter" centered 
-                                                        onHide={() => this.handleToggleDetailsModal(false)}>
-                                                        <Modal.Header closeButton>
-                                                            <Modal.Title>Scene {this.state.currentSceneNum} Details</Modal.Title>
-                                                        </Modal.Header>
-                                                        <Modal.Body>
-                                                            {scenesInOrder && this.state.currentSceneNum <= scenesInOrder.length && this.getCurrentScene(scenesInOrder) !== undefined
-                                                                && this.getCurrentScene(scenesInOrder) !== null &&
-                                                                <div className="scene-table-div">
-                                                                    <table>
-                                                                        <tbody>
-                                                                            {Object.keys(this.getCurrentScene(scenesInOrder)).map((objectKey, key) => 
-                                                                                this.checkSceneObjectKey(this.getCurrentScene(scenesInOrder), objectKey, key))}
-                                                                        </tbody>
-                                                                    </table>
-                                                                    {this.getCurrentScene(scenesInOrder).objects && this.getCurrentScene(scenesInOrder).objects.length > 0 &&
-                                                                        <>
-                                                                            <div className="objects_scenes_header">
-                                                                                <h5>Objects in Scene</h5>
-                                                                            </div>
-                                                                            <div className="object-nav">
-                                                                                <ul className="nav nav-tabs">
-                                                                                    {this.getCurrentScene(scenesInOrder).objects.map((sceneObject, key) => 
-                                                                                        <li className="nav-item" key={'object_tab_' + key}>
-                                                                                            <button id={'object_button_' + key} className={key === 0 ? 'nav-link active' : 'nav-link'} onClick={() => this.changeObjectDisplay(key)}>{this.findObjectTabName(sceneObject)}</button>
-                                                                                        </li>
-                                                                                    )}
-                                                                                </ul>
-                                                                            </div>
-                                                                            <div className="object-contents">
-                                                                                <table>
-                                                                                    <tbody>
-                                                                                        {Object.keys(this.getCurrentScene(scenesInOrder).objects[this.state.currentObjectNum]).map((objectKey, key) => 
-                                                                                            <tr key={'object_tab_' + key}>
-                                                                                                <td className="bold-label">{objectKey}:</td>
-                                                                                                <td className="scene-text">{this.convertValueToString(this.getCurrentScene(scenesInOrder).objects[this.state.currentObjectNum][objectKey])}</td>
-                                                                                            </tr>
-                                                                                        )}
-                                                                                    </tbody>
-                                                                                </table>
-                                                                            </div> 
-                                                                        </>   
-                                                                    }    
-                                                                </div>
-                                                            }
-                                                        </Modal.Body>
-                                                    <Modal.Footer>
-                                                        <Button variant="primary" onClick={() => this.handleToggleDetailsModal(false)}>Close Details</Button>
-                                                    </Modal.Footer>
-                                                </Modal>
-                                                {/* TODO: MCS-517: end modal code */}
 
                                                 { (this.checkIfScenesExist(scenesByPerformer) && this.getSceneHistoryItem(scenesByPerformer) !== undefined && this.getSceneHistoryItem(scenesByPerformer)["category"] !== "interactive") && 
                                                     <div className="classification-by-step">
@@ -734,7 +586,7 @@ class ScenesEval3 extends React.Component {
                                                                             <div id="stepHolder0" className="step-div step-highlight" onClick={() => this.goToVideoLocation(0)}>0: Starting Position</div>
                                                                             {this.getSceneHistoryItem(scenesByPerformer).steps.map((stepObject, key) => 
                                                                             <div key={"step_div_" + key} id={"stepHolder" + (key+1)} className="step-div" onClick={() => this.goToVideoLocation(key+1)}>
-                                                                                {stepObject.stepNumber + ": " + stepObject.action + " (" + this.convertValueToString(stepObject.args) + ") - " + stepObject.output.return_status}
+                                                                                {stepObject.stepNumber + ": " + stepObject.action + " (" + convertValueToString(stepObject.args) + ") - " + stepObject.output.return_status}
                                                                             </div>
                                                                         )}
                                                                     </div>

--- a/analysis-ui/src/components/Analysis/scenesEval3.jsx
+++ b/analysis-ui/src/components/Analysis/scenesEval3.jsx
@@ -431,6 +431,7 @@ class ScenesEval3 extends React.Component {
                                                         changeSceneHandler={this.changeScene}
                                                         scenesInOrder={scenesInOrder}
                                                         constantsObject={constantsObject}
+                                                        sortable={true}
                                                     />
                                                 }
 

--- a/analysis-ui/src/components/Analysis/scoreTable.jsx
+++ b/analysis-ui/src/components/Analysis/scoreTable.jsx
@@ -68,7 +68,20 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
                     <TableRow classes={{ root: 'TableRow'}} className="pointer-on-hover" key={'performer_score_row_' + rowKey} hover selected={currentSceneNum === scoreObj.scene_num} onClick={()=> changeSceneHandler(scoreObj.scene_num)}> 
                         {columns.map((col, colKey) => (
                             <TableCell key={"performer_score_row_" + rowKey + "_col_" + colKey}>
-                                {displayItemText(scoreObj, col.dataKey)}
+                                {col.title === 'Score' &&
+                                    <div className="score-div">
+                                        {displayItemText(scoreObj, col.dataKey) === 'Correct' &&
+                                            <i className='material-icons' style={{color: "#008000", fontSize: '20px'}}>check</i>
+                                        }
+                                        {displayItemText(scoreObj, col.dataKey) === 'Incorrect' &&
+                                            <i className='material-icons' style={{color: "#ff0000", fontSize: '20px'}}>close</i>
+                                        }
+                                        <span className='score-text'>{displayItemText(scoreObj, col.dataKey)}</span>
+                                    </div>
+                                }
+                                {col.title !== 'Score' &&
+                                    displayItemText(scoreObj, col.dataKey)
+                                }
                             </TableCell>
                         ))}
                         <TableCell key={"performer_score_row_" + rowKey + "_col_details"}>

--- a/analysis-ui/src/components/Analysis/scoreTable.jsx
+++ b/analysis-ui/src/components/Analysis/scoreTable.jsx
@@ -10,7 +10,7 @@ import TableSortLabel from "@material-ui/core/TableSortLabel";
 import SceneDetails from './sceneDetails';
 
 function ScoreTable({columns, currentPerformerScenes, currentSceneNum, 
-    changeSceneHandler, scenesInOrder, constantsObject}) {
+    changeSceneHandler, scenesInOrder, constantsObject, sortable}) {
 
     const [sortOption, setSortOption] = useState({sortBy: "", sortOrder: "asc"})
 
@@ -47,10 +47,15 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
                     <TableRow>
                     {columns.map((col, colKey) => (
                         <TableCell key={"performer_score_header_cell_" + colKey}>
-                            <TableSortLabel active={sortOption.sortBy === col.dataKey} direction={sortOption.sortOrder} 
-                                onClick={() => handleRequestSort(col.dataKey)}>
-                                {col.title}
-                            </TableSortLabel>
+                            {sortable &&
+                                <TableSortLabel active={sortOption.sortBy === col.dataKey} direction={sortOption.sortOrder} 
+                                    onClick={() => handleRequestSort(col.dataKey)}>
+                                    {col.title}
+                                </TableSortLabel>
+                            }
+                            {!sortable &&
+                                col.title
+                            }
                         </TableCell>
                     ))}
                         <TableCell key="performer_score_header_cell_details">
@@ -66,15 +71,13 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
                                 {displayItemText(scoreObj, col.dataKey)}
                             </TableCell>
                         ))}
-                            <TableCell key={"performer_score_row_" + rowKey + "_col_details"}>
-
-                                <SceneDetails  
-                                    currentSceneNum={currentSceneNum}
-                                    currentScene={getCurrentScene(scenesInOrder)}
-                                    constantsObject={constantsObject}
-                                />
-                                
-                            </TableCell>
+                        <TableCell key={"performer_score_row_" + rowKey + "_col_details"}>
+                            <SceneDetails  
+                                currentSceneNum={currentSceneNum}
+                                currentScene={getCurrentScene(scenesInOrder)}
+                                constantsObject={constantsObject}
+                            />
+                        </TableCell>
                     </TableRow>
                 )}
                 </TableBody>

--- a/analysis-ui/src/components/Analysis/scoreTable.jsx
+++ b/analysis-ui/src/components/Analysis/scoreTable.jsx
@@ -1,0 +1,86 @@
+import React, {useState} from 'react';
+import _ from "lodash";
+import { convertValueToString } from './displayTextUtils';
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import TableSortLabel from "@material-ui/core/TableSortLabel";
+import SceneDetails from './sceneDetails';
+
+function ScoreTable({columns, currentPerformerScenes, currentSceneNum, 
+    changeSceneHandler, scenesInOrder, constantsObject}) {
+
+    const [sortOption, setSortOption] = useState({sortBy: "", sortOrder: "asc"})
+
+    const getSorting = (order, orderBy) => {
+        return order === "desc"
+        ? (a, b) => (_.get(a, orderBy) > _.get(b, orderBy) ? -1 : 1)
+        : (a, b) => (_.get(a, orderBy) < _.get(b, orderBy) ? -1 : 1);
+    }
+
+    const displayItemText = (row, dataKey) => {
+        let item = _.get(row, dataKey);
+
+        if(item !== undefined && item !== null && item !== "") {
+            return convertValueToString(item);
+        } else {
+            return "";
+        }
+    }
+
+    const handleRequestSort = (property) => {
+        let isAsc = sortOption.sortBy === property && sortOption.sortOrder === 'asc';
+
+        setSortOption({sortOrder: isAsc ? 'desc' : 'asc', sortBy: property})
+    };
+
+    const getCurrentScene = (scenesInOrder) => {
+        return scenesInOrder[currentSceneNum - 1];
+    }
+
+    return (
+        <div className="score-table-div">
+            <Table className="score-table" aria-label="simple table">
+                <TableHead>
+                    <TableRow>
+                    {columns.map((col, colKey) => (
+                        <TableCell key={"performer_score_header_cell_" + colKey}>
+                            <TableSortLabel active={sortOption.sortBy === col.dataKey} direction={sortOption.sortOrder} 
+                                onClick={() => handleRequestSort(col.dataKey)}>
+                                {col.title}
+                            </TableSortLabel>
+                        </TableCell>
+                    ))}
+                        <TableCell key="performer_score_header_cell_details">
+                            Details
+                        </TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                {currentPerformerScenes !== undefined && _.values(currentPerformerScenes).sort(getSorting(sortOption.sortOrder, sortOption.sortBy)).map((scoreObj, rowKey) => 
+                    <TableRow classes={{ root: 'TableRow'}} className="pointer-on-hover" key={'performer_score_row_' + rowKey} hover selected={currentSceneNum === scoreObj.scene_num} onClick={()=> changeSceneHandler(scoreObj.scene_num)}> 
+                        {columns.map((col, colKey) => (
+                            <TableCell key={"performer_score_row_" + rowKey + "_col_" + colKey}>
+                                {displayItemText(scoreObj, col.dataKey)}
+                            </TableCell>
+                        ))}
+                            <TableCell key={"performer_score_row_" + rowKey + "_col_details"}>
+
+                                <SceneDetails  
+                                    currentSceneNum={currentSceneNum}
+                                    currentScene={getCurrentScene(scenesInOrder)}
+                                    constantsObject={constantsObject}
+                                />
+                                
+                            </TableCell>
+                    </TableRow>
+                )}
+                </TableBody>
+            </Table>
+        </div>                                                   
+    );
+}
+
+export default ScoreTable;

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -939,16 +939,6 @@ ol, ul {
     word-wrap: break-word;
 }
 
-.show-details-toggle:hover {
-    /*color: #007bff;*/
-    color: #a2a9b5;
-    cursor: pointer;
-}
-    
-.TableRow.Mui-selected {
-    background-color: #99d6ff !important;
-}
-
 /* Evaluation Stats Page */
 .eval-stats-body {
     background-color: #F8F8F8;
@@ -1028,4 +1018,14 @@ ol, ul {
     position: relative;
     top: -5px;
     left: 5px;
+}
+
+.show-details-toggle:hover {
+    /*color: #007bff;*/
+    color: #a2a9b5;
+    cursor: pointer;
+}
+
+.TableRow.Mui-selected {
+    background-color: #99d6ff !important;
 }

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1018,3 +1018,14 @@ ol, ul {
     top: -8px;
     left: 2px;
 }
+
+/* score table */
+.score-div {
+    padding-top: 5px;
+}
+
+.score-text {
+    position: relative;
+    top: -5px;
+    left: 5px;
+}

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -931,7 +931,7 @@ ol, ul {
     padding: 20px 0 20px 0;
 }
 
-.classification-by-step-header {
+.pointer-on-hover {
     cursor: pointer;
 }
 
@@ -942,6 +942,16 @@ ol, ul {
 .internal-state-cell {
     max-width: 500px;
     word-wrap: break-word;
+}
+
+.show-details-toggle:hover {
+    /*color: #007bff;*/
+    color: #a2a9b5;
+    cursor: pointer;
+}
+    
+.TableRow.Mui-selected {
+    background-color: #99d6ff !important;
 }
 
 /* Evaluation Stats Page */

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -310,11 +310,6 @@ ol, ul {
     border: 0px solid;
 }
 
-.objects_scenes_header {
-    display: flex;
-    margin: 40px 10px 0px 35px;
-}
-
 .movie-steps-holder{
     display: flex;
     margin: 20px 35px;
@@ -367,7 +362,7 @@ ol, ul {
 
 .object-nav, .object-contents {
     display: flex;
-    margin: 10px 50px;
+    margin: 10px;
 }
 
 .object-nav .nav {
@@ -993,4 +988,33 @@ ol, ul {
 
 .eval-chart-table th, td {
     padding: 5px 10px;
+}
+
+/* scene details */
+.scene-details-header {
+    margin: 5px 15px;
+    flex-direction: column;
+    flex: 1;
+}
+
+.scene-title-and-download {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.scene-details-btn-group {
+    padding-top: 10px;
+}
+
+.download-scene {
+    padding-top: 5px;
+    margin-right: 30px;
+}
+
+.download-scene-text {
+    position: relative;
+    top: -8px;
+    left: 2px;
 }

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1021,7 +1021,6 @@ ol, ul {
 }
 
 .show-details-toggle:hover {
-    /*color: #007bff;*/
     color: #a2a9b5;
     cursor: pointer;
 }


### PR DESCRIPTION
- A modal for scene details/download has been added to the score table.
- You can now select the score table row to select a scene, instead of using a button. 
- Some refactoring -- most notably score table and details are now separate components. 