### PR TITLE
MCS-583: Remove usage of old keys collection from codebase

### DIFF
--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -355,7 +355,6 @@ const mcsResolvers = {
 
                     const historyEvalName = "Evaluation " + evalNumber + " Results";
                     const sceneEvalName = "Evaluation " + evalNumber + " Scenes";
-                    console.log(evalNumber, historyEvalName);
 
                     const historyResults =  await mcsDB.db.collection('collection_keys').findOne({"name": historyEvalName});
                     historyKeys = historyResults.keys;


### PR DESCRIPTION
This has a companion ticket in mcs-ingest that actually drops the collection from the database, along with setting up the framework for deployment scripts to be run.