### PR TITLE
Fixes for evaluation references on homepage/header drop downs

### DIFF
--- a/analysis-ui/src/components/Analysis/header.jsx
+++ b/analysis-ui/src/components/Analysis/header.jsx
@@ -71,7 +71,7 @@ class ListItem extends React.Component {
             if(this.props.stateName === 'eval') {
                 // We have 2 cases: "eval 2" and "every other eval"
                 let isValidEval2 = hasTestTypeState && this.props.item === EVAL_2_IDENTIFIER;
-                let isValidOtherEval = hasCatTypeState && (this.props.item !== EVAL_2_IDENTIFIER);
+                let isValidOtherEval = hasCatTypeState && this.props.item !== EVAL_2_IDENTIFIER;
 
                 if(isValidEval2) {
                     paramsToAppend += "&test_type=" + this.props.state["test_type"];
@@ -208,7 +208,7 @@ class EvalNav extends React.Component {
                         <DropListItems fieldName={"eval"} stateName={"eval"} state={this.props.state} updateHandler={this.props.updateHandler}/>
                     </NavDropdown>
 
-                    {(this.props.state.eval !== undefined && this.props.state.eval !== null && (this.props.state.eval !== EVAL_2_IDENTIFIER)) &&
+                    {(this.props.state.eval !== undefined && this.props.state.eval !== null && this.props.state.eval !== EVAL_2_IDENTIFIER) &&
                     <NavDropdown title={"Category Type: " + (
                         (this.props.state.category_type === undefined || this.props.state.category_type === null) ? "None" : this.props.state.category_type)}
                         id="basic-nav-dropdown">

--- a/analysis-ui/src/components/Analysis/header.jsx
+++ b/analysis-ui/src/components/Analysis/header.jsx
@@ -31,6 +31,8 @@ const GET_SUBMISSION_AGG = gql`
         }
   }`;
 
+const EVAL_2_IDENTIFIER = "Evaluation 2 Results";
+
 class ListItem extends React.Component {
 
     updateState(item, stateName) {
@@ -59,29 +61,30 @@ class ListItem extends React.Component {
         } else {
             // Property List for Eval 2 Going Forward
             let hasEvalState = this.props.state["eval"] !== undefined && this.props.state["eval"] !== null;
-            let isEval2 = hasEvalState && this.props.state["eval"].includes("2");
-            let isEval3 = hasEvalState && this.props.state["eval"].includes("3");
+            let isEval2 = hasEvalState && this.props.state["eval"] === EVAL_2_IDENTIFIER
+            let isNotEval2 = hasEvalState && this.props.state["eval"] !== EVAL_2_IDENTIFIER
             let hasTestTypeState = this.props.state["test_type"] !== undefined && this.props.state["test_type"] !== null;
             let hasCatTypeState = this.props.state["category_type"] !== undefined && this.props.state["category_type"] !== null;
             let hasTestNumState = this.props.state["test_num"] !== undefined && this.props.state["test_num"] !== null;
             let paramsToAppend = '';
 
             if(this.props.stateName === 'eval') {
-                let isValidEval2 = hasTestTypeState && this.props.item.includes("2");
-                let isValidEval3 = hasCatTypeState && this.props.item.includes("3");
+                // We have 2 cases: "eval 2" and "every other eval"
+                let isValidEval2 = hasTestTypeState && this.props.item === EVAL_2_IDENTIFIER;
+                let isValidOtherEval = hasCatTypeState && (this.props.item !== EVAL_2_IDENTIFIER);
 
                 if(isValidEval2) {
                     paramsToAppend += "&test_type=" + this.props.state["test_type"];
-                } else if(isValidEval3) {
+                } else if(isValidOtherEval) {
                     paramsToAppend += "&category_type=" + this.props.state["category_type"];
                 }
 
-                if(hasTestNumState && (isValidEval2 || isValidEval3)) {
+                if(hasTestNumState && (isValidEval2 || isValidOtherEval)) {
                     paramsToAppend += "&test_num=" + this.props.state["test_num"];
                 }
     
                 params = "?eval=" + this.props.item + paramsToAppend;
-            } else if(hasEvalState && isEval2 && this.props.stateName === 'test_type') {
+            } else if(isEval2 && this.props.stateName === 'test_type') {
 
                 paramsToAppend += "&test_type=" + this.props.item;
 
@@ -90,7 +93,7 @@ class ListItem extends React.Component {
                 }
 
                 params = "?eval=" + this.props.state["eval"] + paramsToAppend;
-            } else if(hasEvalState && isEval3 && this.props.stateName === 'category_type') {
+            } else if(isNotEval2 && this.props.stateName === 'category_type') {
 
                 paramsToAppend += "&category_type=" + this.props.item;
 
@@ -102,7 +105,7 @@ class ListItem extends React.Component {
             } else if(hasEvalState && this.props.stateName === 'test_num') {
                 if(hasTestTypeState && isEval2) {
                     paramsToAppend += "&test_type=" + this.props.state["test_type"];
-                } else if(hasCatTypeState && isEval3) {
+                } else if(hasCatTypeState && isNotEval2) {
                     paramsToAppend += "&category_type=" + this.props.state["category_type"];
                 }
 
@@ -205,14 +208,14 @@ class EvalNav extends React.Component {
                         <DropListItems fieldName={"eval"} stateName={"eval"} state={this.props.state} updateHandler={this.props.updateHandler}/>
                     </NavDropdown>
 
-                    {(this.props.state.eval !== undefined && this.props.state.eval !== null && this.props.state.eval.includes("3")) &&
+                    {(this.props.state.eval !== undefined && this.props.state.eval !== null && (this.props.state.eval !== EVAL_2_IDENTIFIER)) &&
                     <NavDropdown title={"Category Type: " + (
                         (this.props.state.category_type === undefined || this.props.state.category_type === null) ? "None" : this.props.state.category_type)}
                         id="basic-nav-dropdown">
                         <DropListItems fieldName={"category_type"} stateName={"category_type"} state={this.props.state} updateHandler={this.props.updateHandler}/>
                     </NavDropdown>}
 
-                    {(this.props.state.eval !== undefined && this.props.state.eval !== null && this.props.state.eval.includes("2")) &&
+                    {(this.props.state.eval !== undefined && this.props.state.eval !== null && this.props.state.eval === EVAL_2_IDENTIFIER) &&
                     <NavDropdown title={"Test Type: " + (
                         (this.props.state.test_type === undefined || this.props.state.test_type === null) ? "None" : this.props.state.test_type)}
                         id="basic-nav-dropdown">

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -44,8 +44,8 @@ const create_complex_query = gql`
     }`;
 
 const mcs_scene= gql`
-    query getEvalScene($sceneName: String, $testNum: Int){
-        getEvalScene(sceneName: $sceneName, testNum: $testNum) {
+    query getEvalScene($eval: String, $sceneName: String, $testNum: Int){
+        getEvalScene(eval: $eval, sceneName: $sceneName, testNum: $testNum) {
             name
             ceilingMaterial
             floorMaterial
@@ -278,7 +278,8 @@ class Scenes extends React.Component {
                     if(metadataList.length > 0 && performerList.length > 0 && sceneNamePrefix !== null) {
                         return (
                             <Query query={mcs_scene} variables={
-                                {"sceneName": sceneNamePrefix, 
+                                {"eval": this.props.value.eval,
+                                "sceneName": sceneNamePrefix, 
                                 "testNum": parseInt(this.props.value.test_num)
                                 }}>
                             {

--- a/analysis-ui/src/components/App/index.jsx
+++ b/analysis-ui/src/components/App/index.jsx
@@ -61,7 +61,7 @@ const AnalysisUI = ({newState, updateHandler}) => {
     }
 
     let hasEval =  (newState.eval !== undefined && newState.eval !== null)
-    let isEval2 = hasEval && newState.eval.includes(" 2 ");
+    let isEval2 = hasEval && newState.eval === 'Evaluation 2 Results';
     let hasCatType = (newState.category_type !== undefined && newState.category_type !== null)
     let hasTestType = (newState.test_type !== undefined && newState.test_type !== null)
     let hasTestNum = (newState.test_num !== undefined && newState.test_num !== null)

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -310,9 +310,9 @@ const mcsResolvers = {
                     let evalNumber;
 
                     if(mongoQueryObject.historyQuery["eval"] !== undefined) {
-                        evalNumber = mongoQueryObject.historyQuery["eval"].replace(/\D/g, "");
+                        evalNumber = mongoQueryObject.historyQuery["eval"].replace(/\D+\.?\D+/g, "");
                     } else {
-                        evalNumber = mongoQueryObject.sceneQuery["mcsScenes.eval"].replace(/\D/g, "");
+                        evalNumber = mongoQueryObject.sceneQuery["mcsScenes.eval"].replace(/\D+\.?\D+/g, "");
                     }
 
                     const historyEvalName = "Evaluation " + evalNumber + " Results";

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -103,7 +103,7 @@ const mcsTypeDefs = gql`
     msc_eval: [Source]
     getEval2History(testType: String, testNum: Int) : [History]
     getEval2Scene(testType: String, testNum: Int) : [Scene]
-    getEvalScene(sceneName: String, testNum: Int) : [Scene]
+    getEvalScene(eval: String, sceneName: String, testNum: Int) : [Scene]
     getEvalByTest(test: String) : [Source]
     getEvalByBlock(block: String) : [Source]
     getEvalBySubmission(submission: String) : [Source]
@@ -131,6 +131,10 @@ const mcsTypeDefs = gql`
   }
 `;
 
+const getEvalNumFromString = (strValue) => {
+    return strValue.replace(/\D+\.?\D+/g, "");
+}
+
 const mcsResolvers = {
     Query: {
         msc_eval: async(obj, args, context, infow) => {
@@ -139,17 +143,20 @@ const mcsResolvers = {
         },
         getEval2History: async(obj, args, context, infow) => {
             // Eval 2
-            return await mcsDB.db.collection('mcs_history').find({'test_type': args["testType"], 'test_num': args["testNum"]})
+            return await mcsDB.db.collection('mcs_history').find({'eval': "Evaluation 2 Results", 'test_type': args["testType"], 'test_num': args["testNum"]})
                 .toArray().then(result => {return result});
         },
         getEval2Scene: async(obj, args, context, infow) => {
             // Eval 2
-            return await mcsDB.db.collection('mcs_scenes').find({'test_type': args["testType"], 'test_num': args["testNum"]})
+            return await mcsDB.db.collection('mcs_scenes').find({'eval': "Evaluation 2 Scenes", 'test_type': args["testType"], 'test_num': args["testNum"]})
                 .toArray().then(result => {return result});
         },
         getEvalScene: async(obj, args, context, infow) => {
             // Eval 3 onwards
-            return await mcsDB.db.collection('mcs_scenes').find({'name': {$regex: args["sceneName"]}, 'test_num': args["testNum"]})
+            let evalNum = getEvalNumFromString(args["eval"]);
+            let sceneEvalName = "Evaluation " + evalNum + " Scenes";
+
+            return await mcsDB.db.collection('mcs_scenes').find({'eval': sceneEvalName, 'name': {$regex: args["sceneName"]}, 'test_num': args["testNum"]})
                 .toArray().then(result => {return result});
         },
         getHistorySceneFieldAggregation: async(obj, args, context, infow) => {
@@ -310,9 +317,9 @@ const mcsResolvers = {
                     let evalNumber;
 
                     if(mongoQueryObject.historyQuery["eval"] !== undefined) {
-                        evalNumber = mongoQueryObject.historyQuery["eval"].replace(/\D+\.?\D+/g, "");
+                        evalNumber = getEvalNumFromString(mongoQueryObject.historyQuery["eval"]);
                     } else {
-                        evalNumber = mongoQueryObject.sceneQuery["mcsScenes.eval"].replace(/\D+\.?\D+/g, "");
+                        evalNumber = getEvalNumFromString(mongoQueryObject.sceneQuery["mcsScenes.eval"]);
                     }
 
                     const historyEvalName = "Evaluation " + evalNumber + " Results";


### PR DESCRIPTION
- Fixing places where we were checking for eval 2 code with "includes("2")" (I used that when we weren't really sure about naming conventions, but now we can reliably use "Evaluation 2 Results")
- Likewise, removing anything specifically looking for eval 3 like "includes("3")" from the header dropdown on the Analysis UI page so that future evals like Eval 4 still work. 
- Adding eval argument to the history/scene queries, so we're not just depending on category type/test type and number
- Fixed a bug with eval regex in server.schema