### PR TITLE
Query Results Table Search Bar

### DIFF
--- a/analysis-ui/src/components/QueryBuilder/queryResultsTable.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryResultsTable.jsx
@@ -110,7 +110,7 @@ function QueryResultsSearchBar({setSearch, searchCategories, setSearchCategory, 
     return (
         <div className="table-query-search-container">
             <div className="table-query-search-container">
-                <span className="material-icons icon-margin-left" style={{paddingRight: "5px", paddingTop: "7px", borderBottom: "1px solid", borderBottomStyle:"inset"}}>
+                <span className="material-icons icon-margin-left table-query-search-icon">
                         search
                 </span>
                 <input className="table-query-search-bar" type="text" id="loadQuerySearchBar" placeholder="Search..." onChange={(e)=>setSearchInputTextValue(e.target.value)}/>

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -949,6 +949,12 @@ ol, ul {
     display: flex;
 }
 
+.table-query-search-icon {
+    padding-right: 5px; 
+    padding-top: 7px;
+    border-bottom: 1px solid; 
+    border-bottom-style: inset;
+}
 
 .table-query-search-bar {
     border:0; 

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -945,6 +945,22 @@ ol, ul {
     padding: 5px;
 }
 
+.table-query-search-container {
+    display: flex;
+}
+
+
+.table-query-search-bar {
+    border:0; 
+    outline:0; 
+    border-bottom: 1px solid; 
+    border-bottom-style: inset;
+}
+
+.table-query-search-button {
+    border-radius: 10px;
+}
+
 ::-webkit-scrollbar {
     -webkit-appearance: none;
     width: 7px;


### PR DESCRIPTION
I looked at the zeplin page as a reference. I thought I should add extra functionality on top of what was there. The "**All Rows**" button searches all of the rows in the table, not just the 5, 10, or 25 currently displayed in the table. I added a "**Search"** button because typing the search and updating the searches realtime with each letter input would cause the application to freeze as it looped though all the options each input. The categories limits the search to a specific category. Searches also work when the table is grouped.