### PR TITLE
Fix scene history query for analysis UI page for Eval 4

### DIFF
--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -224,7 +224,7 @@ class Scenes extends React.Component {
                 fieldNameLabel: "Test Type",
                 fieldValue1: categoryType,
                 fieldValue2: "",
-                functionOperator: "contains",
+                functionOperator: "equals",
                 collectionDropdownToggle: 1
             },
             {


### PR DESCRIPTION
One line change -- I think this contains query on category for getting the history records per test may cause issues now that we have things like "interactive object permanence" vs "object permanence", so wanted to address it now.