### PR TITLE
Analysis query fix

### DIFF
--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -225,6 +225,8 @@ class Scenes extends React.Component {
     // (grabbing those things seperately from the history record
     // breaks sorting on the score table)
     getSceneHistoryQueryObject = (evalName, categoryType, testNum) => {
+        let sceneColEvalName = evalName.replace("Results", "Scenes");
+
         return [
             {
                 fieldType: "mcs_history." + evalName,
@@ -242,6 +244,16 @@ class Scenes extends React.Component {
                 fieldName: "test_num",
                 fieldNameLabel: "Test Number",
                 fieldValue1: parseInt(testNum),
+                fieldValue2: "",
+                functionOperator: "equals",
+                collectionDropdownToggle: 1
+            },
+            {
+                fieldType:"mcs_scenes." + sceneColEvalName,
+                fieldTypeLabel: sceneColEvalName,
+                fieldName: "eval",
+                fieldNameLabel: "Evaluation Name",
+                fieldValue1: sceneColEvalName,
                 fieldValue2: "",
                 functionOperator: "equals",
                 collectionDropdownToggle: 1

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -251,9 +251,9 @@ class Scenes extends React.Component {
             {
                 fieldType:"mcs_scenes." + sceneColEvalName,
                 fieldTypeLabel: sceneColEvalName,
-                fieldName: "eval",
-                fieldNameLabel: "Evaluation Name",
-                fieldValue1: sceneColEvalName,
+                fieldName: "goal.sceneInfo.tertiaryType",
+                fieldNameLabel: "Tertiary Type",
+                fieldValue1: categoryType,
                 fieldValue2: "",
                 functionOperator: "equals",
                 collectionDropdownToggle: 1


### PR DESCRIPTION
Found this a couple days ago when playing with dev graphql -- it looked like there were duplicates at first, but then realized I likely need an extra clause to specify which scene data to pull since we're sharing names/descriptions for things in Eval 4. 

Now that I'm looking at this again, I'm wondering if there's something with the complex query itself that should be updated instead (I was able to do something similar in dev on the Query Builder page to demonstrate, if you examine the scene info on the query I saved in dev for "MESS golf Eval 4 Results Query", but that could also be user error since I only used history collection fields and not one from "scene" as well). 