### PR TITLE
MCS-1009 Fix scene history query on analysis UI page

### DIFF
--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
-import _, { forEach } from "lodash";
+import _ from "lodash";
 // TODO: Remove FlagCheckboxMutation component + currentState + related variables?
 //import FlagCheckboxMutation from './flagCheckboxMutation';
 import {EvalConstants} from './evalConstants';
@@ -11,40 +11,11 @@ import InteractiveScenePlayer from './interactiveScenePlayer';
 import PlaybackButtons from './playbackButtons'
 import PlausabilityGraph from './plausabilityGraph';
 
-const historyQueryName = "createComplexQuery";
-const historyQueryResults = "results";
+const historyQueryName = "getEvalHistory";
 const sceneQueryName = "getEvalScene";
 
 let constantsObject = {};
 //let currentState = {};
-
-const projectionObject = {
-    "eval": 1,
-    "performer": 1,
-    "name": 1,
-    "test_type": 1,
-    "test_num": 1,
-    "scene_num": 1,
-    "scene_goal_id": 1,
-    "score": 1,
-    "steps": 1,
-    "flags": 1,
-    "metadata": 1,
-    "step_counter": 1,
-    "category": 1,
-    "category_type": 1,
-    "category_pair": 1,
-    "fullFilename": 1,
-    "filename": 1,
-    "fileTimestamp": 1,
-    "corner_visit_order": 1,
-    "scene.goal.sceneInfo.slices": "$mcsScenes.goal.sceneInfo.slices"
-}
-
-const create_complex_query = gql`
-    query createComplexQuery($queryObject: JSON!, $projectionObject: JSON!) {
-        createComplexQuery(queryObject: $queryObject, projectionObject: $projectionObject) 
-    }`;
 
 const mcs_scene= gql`
     query getEvalScene($eval: String, $sceneName: String, $testNum: Int){
@@ -61,19 +32,45 @@ const mcs_scene= gql`
             test_num
             scene_num
         }
-  }`;
+    }`;
+
+
+const mcs_history = gql`
+    query getEvalHistory($eval: String, $categoryType: String, $testNum: Int){
+        getEvalHistory(eval: $eval, categoryType: $categoryType, testNum: $testNum) {
+            eval
+            performer
+            name
+            test_type
+            test_num
+            scene_num
+            scene_goal_id
+            score
+            steps
+            flags
+            metadata
+            step_counter
+            category
+            category_type
+            category_pair
+            fullFilename
+            filename
+            fileTimestamp
+            corner_visit_order
+        }
+    }`;
 
 const setConstants = function(evalNum) {
     constantsObject = EvalConstants[evalNum];
 }
 
 const scoreTableCols = [
-    { dataKey: 'scene_num', title: 'Scene' },
-    { dataKey: 'scene_goal_id', title: 'Goal ID'},
-    { dataKey: 'scene.goal.sceneInfo.slices', title: 'Slices'},
-    { dataKey: 'score.classification', title: 'Classification' },
-    { dataKey: 'score.score_description', title: 'Score'},
-    { dataKey: 'score.confidence', title: 'Confidence' }
+    { dataKey: 'scene_num', title: 'Scene', dataType: 'history'},
+    { dataKey: 'scene_goal_id', title: 'Goal ID', dataType: 'history'},
+    { dataKey: 'goal.sceneInfo.slices', title: 'Slices', dataType: 'scene'},
+    { dataKey: 'score.classification', title: 'Classification', dataType: 'history'},
+    { dataKey: 'score.score_description', title: 'Score', dataType: 'history'},
+    { dataKey: 'score.confidence', title: 'Confidence', dataType: 'history'}
 ]
 
 const scoreTableColsWithCorners = scoreTableCols.concat([{ dataKey: 'corner_visit_order', title: 'Corner Visit Order'}])
@@ -219,48 +216,6 @@ class Scenes extends React.Component {
         return name.substring(0, name.indexOf('_')) + '*';
     }
 
-    // TODO: investigating update history query for eval 3+ onwards
-    // currently there are fields needed that are on the scene record
-    // and not the history record, so a projection query is done
-    // (grabbing those things seperately from the history record
-    // breaks sorting on the score table)
-    getSceneHistoryQueryObject = (evalName, categoryType, testNum) => {
-        let sceneColEvalName = evalName.replace("Results", "Scenes");
-
-        return [
-            {
-                fieldType: "mcs_history." + evalName,
-                fieldTypeLabel: evalName,
-                fieldName: "category_type",
-                fieldNameLabel: "Test Type",
-                fieldValue1: categoryType,
-                fieldValue2: "",
-                functionOperator: "equals",
-                collectionDropdownToggle: 1
-            },
-            {
-                fieldType: "mcs_history." + evalName,
-                fieldTypeLabel: evalName,
-                fieldName: "test_num",
-                fieldNameLabel: "Test Number",
-                fieldValue1: parseInt(testNum),
-                fieldValue2: "",
-                functionOperator: "equals",
-                collectionDropdownToggle: 1
-            },
-            {
-                fieldType:"mcs_scenes." + sceneColEvalName,
-                fieldTypeLabel: sceneColEvalName,
-                fieldName: "goal.sceneInfo.tertiaryType",
-                fieldNameLabel: "Tertiary Type",
-                fieldValue1: categoryType,
-                fieldValue2: "",
-                functionOperator: "equals",
-                collectionDropdownToggle: 1
-            }
-        ]
-    }
-
     checkIfScenesExist = (scenesByPerformer) =>{
         return scenesByPerformer !== undefined && scenesByPerformer[this.state.currentMetadataLevel] !== undefined
             && scenesByPerformer[this.state.currentMetadataLevel][this.state.currentPerformer] !== undefined;
@@ -367,22 +322,19 @@ class Scenes extends React.Component {
 
     render() {
         return (
-            <Query query={create_complex_query} variables={
+            <Query query={mcs_history} variables={
                 {    
-                    "queryObject":  this.getSceneHistoryQueryObject(
-                        this.props.value.eval,
-                        this.props.value.category_type,
-                        this.props.value.test_num
-                    ), 
-                    "projectionObject": projectionObject
+                    "eval": this.props.value.eval,
+                    "categoryType": this.props.value.category_type, 
+                    "testNum": parseInt(this.props.value.test_num)
                 }}
                 onCompleted={() => { if(this.props.value.scene === null) { this.changeScene(1); }}}>
             {
                 ({ loading, error, data }) => {
                     if (loading) return <div>Loading ...</div> 
                     if (error) return <div>Error</div>
-                    
-                    const evals = data[historyQueryName][historyQueryResults];
+
+                    const evals = data[historyQueryName];
 
                     let sortedScenes =  _.sortBy(evals, "scene_num");
                     let scenesByMetadata = _.groupBy(sortedScenes, "metadata");

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -73,7 +73,7 @@ const scoreTableCols = [
     { dataKey: 'score.confidence', title: 'Confidence', dataType: 'history'}
 ]
 
-const scoreTableColsWithCorners = scoreTableCols.concat([{ dataKey: 'corner_visit_order', title: 'Corner Visit Order'}])
+const scoreTableColsWithCorners = scoreTableCols.concat([{ dataKey: 'corner_visit_order', title: 'Corner Visit Order', dataType: 'history'}])
 
 class Scenes extends React.Component {
 

--- a/analysis-ui/src/components/Analysis/scoreTable.jsx
+++ b/analysis-ui/src/components/Analysis/scoreTable.jsx
@@ -47,13 +47,13 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
                     <TableRow>
                     {columns.map((col, colKey) => (
                         <TableCell key={"performer_score_header_cell_" + colKey}>
-                            {sortable &&
+                            {sortable && col.dataType !== 'scene' &&
                                 <TableSortLabel active={sortOption.sortBy === col.dataKey} direction={sortOption.sortOrder} 
                                     onClick={() => handleRequestSort(col.dataKey)}>
                                     {col.title}
                                 </TableSortLabel>
                             }
-                            {!sortable &&
+                            {((!sortable) || col.dataType === 'scene') &&
                                 col.title
                             }
                         </TableCell>
@@ -68,7 +68,7 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
                     <TableRow classes={{ root: 'TableRow'}} className="pointer-on-hover" key={'performer_score_row_' + rowKey} hover selected={currentSceneNum === scoreObj.scene_num} onClick={()=> changeSceneHandler(scoreObj.scene_num)}> 
                         {columns.map((col, colKey) => (
                             <TableCell key={"performer_score_row_" + rowKey + "_col_" + colKey}>
-                                {col.title === 'Score' &&
+                                {col.dataType === 'history' && col.title === 'Score' &&
                                     <div className="score-div">
                                         {displayItemText(scoreObj, col.dataKey) === 'Correct' &&
                                             <i className='material-icons' style={{color: "#008000", fontSize: '20px'}}>check</i>
@@ -79,8 +79,15 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
                                         <span className='score-text'>{displayItemText(scoreObj, col.dataKey)}</span>
                                     </div>
                                 }
-                                {col.title !== 'Score' &&
-                                    displayItemText(scoreObj, col.dataKey)
+                                {col.dataType === 'history' && col.title !== 'Score' &&
+                                    <div>
+                                        {displayItemText(scoreObj, col.dataKey)}
+                                    </div>
+                                }
+                                {col.dataType === 'scene' &&
+                                    <div>
+                                        {displayItemText(scenesInOrder[scoreObj.scene_num - 1], col.dataKey)}
+                                    </div>
                                 }
                             </TableCell>
                         ))}

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -62,6 +62,8 @@ const mcsTypeDefs = gql`
     metadata: String
     filename: String
     fileTimestamp: String
+    fullFilename: String
+    corner_visit_order: [JSON]
   }
 
   type Scene {
@@ -115,6 +117,7 @@ const mcsTypeDefs = gql`
 
   type Query {
     msc_eval: [Source]
+    getEvalHistory(eval: String, categoryType: String, testNum: Int) : [History]
     getEval2History(catTypePair: String, testNum: Int) : [History]
     getEval2Scene(testType: String, testNum: Int) : [Scene]
     getEvalScene(eval: String, sceneName: String, testNum: Int) : [Scene]
@@ -179,6 +182,12 @@ const mcsResolvers = {
             let sceneEvalName = "Evaluation " + evalNum + " Scenes";
 
             return await mcsDB.db.collection(SCENES_COLLECTION).find({'eval': sceneEvalName, 'name': {$regex: args["sceneName"]}, 'test_num': args["testNum"]})
+                .toArray().then(result => {return result});
+        },
+        getEvalHistory: async(obj, args, context, infow) => {
+            // Eval 3 onwards
+            return await mcsDB.db.collection(HISTORY_COLLECTION).find({'eval': args["eval"], 
+                'category_type': args["categoryType"], 'test_num': args["testNum"]})
                 .toArray().then(result => {return result});
         },
         getHistorySceneFieldAggregation: async(obj, args, context, infow) => {


### PR DESCRIPTION
Abandoning using createComplexQuery on the scene analysis page and switching to a more accurate query for scene history (using eval, category_type, and test_num).