### PR TITLE
Fixing debug file names for non-agency scenes (MCS-970).

### DIFF
--- a/analysis-ui/src/components/Analysis/sceneDetails.jsx
+++ b/analysis-ui/src/components/Analysis/sceneDetails.jsx
@@ -66,6 +66,12 @@ function SceneDetailsModal({show, onHide, currentSceneNum, currentScene, constan
             sceneName =  currentScene.name.replace("juliett", "juliett_rerun")
         }
 
+        if(currentScene.eval !== undefined && currentScene.eval === "Evaluation 4 Scenes"
+            && currentScene.goal.category !== 'agents') {
+            // Goal ID is part of debug file names for Eval 4
+            sceneName = sceneName.concat("_", currentScene.goal.sceneInfo.id[0])
+        }
+
         return constantsObject["sceneBucket"] + sceneName + constantsObject["sceneExtension"]
     }
 

--- a/analysis-ui/src/components/Analysis/scenesEval2.jsx
+++ b/analysis-ui/src/components/Analysis/scenesEval2.jsx
@@ -56,11 +56,11 @@ const setConstants = function(evalNum) {
 }
 
 const scoreTableCols = [
-    { dataKey: 'scene_num', title: 'Scene' },
-    { dataKey: 'score.classification', title: 'Answer' },
-    { dataKey: 'score.score_description', title: 'Score'},
-    { dataKey: 'score.adjusted_confidence', title: 'Adjusted Confidence' },
-    { dataKey: 'score.confidence', title: 'Confidence' }
+    { dataKey: 'scene_num', title: 'Scene', dataType: 'history'},
+    { dataKey: 'score.classification', title: 'Answer', dataType: 'history'},
+    { dataKey: 'score.score_description', title: 'Score', dataType: 'history'},
+    { dataKey: 'score.adjusted_confidence', title: 'Adjusted Confidence', dataType: 'history'},
+    { dataKey: 'score.confidence', title: 'Confidence', dataType: 'history'}
 ]
 
 // TODO: Merge back in with Scenes view?


### PR DESCRIPTION
UI should link correctly for eval 4 *_debug.json files now + snuck in a fix for the score table for eval 2 scenes. 