### PR TITLE
MCS-1060:  Add do not answer and toggle to Test Overview

### DIFF
--- a/analysis-ui/package.json
+++ b/analysis-ui/package.json
@@ -40,6 +40,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "3.2.0",
         "react-select": "^3.1.1",
+        "react-switch": "^6.0.0",
         "react-textarea-autosize": "^7.1.2",
         "rxjs": "^6.6.3",
         "typescript": "^3.6.4"

--- a/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
+++ b/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
@@ -23,6 +23,7 @@ const overViewTableFields = [
     {"title": "Correct Implausible", "key": "correct_implausible"},
     {"title": "Incorrect Implausible", "key": "incorrect_implausible"},
     {"title": "False Alarm", "key": "falseAlarm"},
+    {"title": "No Answer", "key": "did_not_answer"},
     {"title": "Total", "key": "total"},
     {"title": "Mean", "key": "mean"},
     {"title": "dPrime", "key": "dPrime"},
@@ -84,6 +85,8 @@ class HyperCubeResultsTable extends React.Component {
 
                     const tableTitle = "Overview Stats (" + this.props.state.category + "/" + 
                         this.props.state.performer + "/" + this.props.state.metadata + ")";
+
+                    console.log(hyperCubeData);
 
                     return (
                         <>

--- a/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
+++ b/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
@@ -11,19 +11,20 @@ import ScoreCardTable from './scorecardTable';
 
 const hyperCubeDataQueryName = "getTestOverviewData";
 const getHyperCubeData = gql`
-    query getTestOverviewData($eval: String!, $categoryType: String!, $performer: String!, $metadata: String!) {
-        getTestOverviewData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata) 
+    query getTestOverviewData($eval: String!, $categoryType: String!, $performer: String!, $metadata: String!, $useDidNotAnswer: Boolean!) {
+        getTestOverviewData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata, useDidNotAnswer: $useDidNotAnswer) 
     }`;
 
 const overViewTableFields = [
     {"title": "HyperCubeId", "key": "hyperCubeID"},
     {"title": "Correct Plausible", "key": "correct_plausible"},
     {"title": "Incorrect Plausible", "key": "incorrect_plausible"},
+    {"title": "No Answer Plausible", "key": "did_not_answer_plausible"},
     {"title": "Hit Rate", "key": "hitRate"},
     {"title": "Correct Implausible", "key": "correct_implausible"},
     {"title": "Incorrect Implausible", "key": "incorrect_implausible"},
+    {"title": "No Answer Implausible", "key": "did_not_answer_implausible"},
     {"title": "False Alarm", "key": "falseAlarm"},
-    {"title": "No Answer", "key": "did_not_answer"},
     {"title": "Total", "key": "total"},
     {"title": "Mean", "key": "mean"},
     {"title": "dPrime", "key": "dPrime"},
@@ -74,7 +75,8 @@ class HyperCubeResultsTable extends React.Component {
                 "eval": this.props.state.eval,
                 "categoryType": this.props.state.category,
                 "performer": this.props.state.performer,
-                "metadata": this.props.state.metadata}}>
+                "metadata": this.props.state.metadata,
+                "useDidNotAnswer": this.props.state.useDidNotAnswer}}>
             {
                 ({ loading, error, data }) => {
                     if (loading) return <div>Loading ...</div> 
@@ -86,7 +88,6 @@ class HyperCubeResultsTable extends React.Component {
                     const tableTitle = "Overview Stats (" + this.props.state.category + "/" + 
                         this.props.state.performer + "/" + this.props.state.metadata + ")";
 
-                    console.log(hyperCubeData);
 
                     return (
                         <>

--- a/analysis-ui/src/components/TestOverview/overview.jsx
+++ b/analysis-ui/src/components/TestOverview/overview.jsx
@@ -3,6 +3,7 @@ import EvalNavItem from './evalNavItem';
 import CategoryNavItem from './categoryNavItem';
 import ButtonGroupNavItem from './buttonGroupNavItem';
 import HyperCubeResultsTable from './hypercubeResultsTable';
+import Switch from "react-switch";
 
 class TestOverview extends React.Component {
 
@@ -12,13 +13,19 @@ class TestOverview extends React.Component {
             eval: "",
             category: "",
             performer: "",
-            metadata: ""
+            metadata: "",
+            useDidNotAnswer: true
         }
         this.stateUpdateHandler = this.stateUpdateHandler.bind(this);
+        this.toggleUseDidNotAnswer = this.toggleUseDidNotAnswer.bind(this);
     }
 
     stateUpdateHandler(key, value) {
         this.setState({[key]: value});
+    }
+
+    toggleUseDidNotAnswer() {
+        this.setState(prevState => ({useDidNotAnswer: !prevState.useDidNotAnswer}));
     }
 
     render() {
@@ -51,6 +58,12 @@ class TestOverview extends React.Component {
                                         <ButtonGroupNavItem fieldName="performer" state={this.state} stateUpdateHandler={this.stateUpdateHandler}/>
                                     </div>
                                     <div className="overview-buttom-group-right">
+                                        <label className="no-answer-toggle-holder">
+                                            <div className="switch-container">
+                                                <Switch onChange={this.toggleUseDidNotAnswer} checked={this.state.useDidNotAnswer}/>
+                                            </div>
+                                            <span>Include No Answers in Calculations</span>
+                                        </label>
                                         <ButtonGroupNavItem fieldName="metadata" state={this.state} stateUpdateHandler={this.stateUpdateHandler}/>
                                     </div>
                                 </div>

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1226,3 +1226,14 @@ nav.MuiList-root.nav-list.MuiList-padding {
     top: -50px;
     z-index: 3;
 }
+
+.no-answer-toggle-holder {
+    margin-right: 20px;
+}
+
+.switch-container {
+    position: relative;
+    display: inline-block;
+    top: 6px;
+    margin-right: 5px;
+}

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -521,7 +521,8 @@ const mcsResolvers = {
                 "hypercube_id": "$scene_goal_id",
                 "groundTruth": "$score.ground_truth",
                 "scoreWorth": "$score.weighted_score_worth",
-                "testType": "$test_type"
+                "testType": "$test_type",
+                "description": "$score.score_description"
             };
 
             if(args.categoryType.toLowerCase().indexOf("agents") > -1) {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -139,7 +139,7 @@ const mcsTypeDefs = gql`
     getEvalTestTypes(eval: String): [String]
     getHomeChartOptions(eval: String, evalType: String): JSON
     getHomeChart(eval: String, evalType: String, isPercent: Boolean, metadata: String, isPlausibility: Boolean, isNovelty: Boolean, isWeighted: Boolean): JSON
-    getTestOverviewData(eval: String, categoryType: String, performer: String, metadata: String): JSON
+    getTestOverviewData(eval: String, categoryType: String, performer: String, metadata: String, useDidNotAnswer: Boolean): JSON
     getScoreCardData(eval: String, categoryType: String, performer: String, metadata: String): JSON
   }
 
@@ -533,7 +533,7 @@ const mcsResolvers = {
                 {"$match": searchObject}, {"$group": {"_id": projectObject, "count": {"$sum": 1}}
             }]).toArray();
 
-            return processHyperCubeStats(hypercubeStats);
+            return processHyperCubeStats(hypercubeStats, args.useDidNotAnswer);
         },
         getScoreCardData: async(obj, args, context, infow) =>{
             const searchObject = {

--- a/node-graphql/server.statsFunctions.js
+++ b/node-graphql/server.statsFunctions.js
@@ -356,6 +356,10 @@ function updateStatObj(hyperCubeObj, statObj) {
         } else if(hyperCubeObj["_id"]["groundTruth"] === 0) {
             statObj["incorrect_implausible"] += hyperCubeObj["count"] * hyperCubeObj["_id"]["scoreWorth"];
         }
+
+        if(hyperCubeObj["_id"]["description"] === "No answer") {
+            statObj["did_not_answer"] += hyperCubeObj["count"];
+        }
     }
 }
 
@@ -373,7 +377,8 @@ function processHyperCubeStats(hyperCubeProjection) {
                 "correct_plausible": 0,
                 "correct_implausible": 0,
                 "incorrect_plausible": 0,
-                "incorrect_implausible": 0
+                "incorrect_implausible": 0,
+                "did_not_answer": 0
             };
             updateStatObj(hyperCubeProjection[i], newStatObj);
             statArray.push(newStatObj);
@@ -387,13 +392,15 @@ function processHyperCubeStats(hyperCubeProjection) {
         "correct_plausible": 0,
         "correct_implausible": 0,
         "incorrect_plausible": 0,
-        "incorrect_implausible": 0
+        "incorrect_implausible": 0,
+        "did_not_answer": 0
     };
     for(let j = 0; j < statArray.length; j++) {
         totalStatObj["correct_plausible"] += statArray[j]["correct_plausible"];
         totalStatObj["correct_implausible"] += statArray[j]["correct_implausible"];
         totalStatObj["incorrect_plausible"] += statArray[j]["incorrect_plausible"];
         totalStatObj["incorrect_implausible"] += statArray[j]["incorrect_implausible"];
+        totalStatObj["did_not_answer"] += statArray[j]["did_not_answer"];
     }
     statArray.push(totalStatObj);
 


### PR DESCRIPTION
Below you can see that we added new columns for do not answer for plausible and implausible, currently with the toggle they are included in the calculations:
![Screen Shot 2021-12-17 at 4 43 13 PM](https://user-images.githubusercontent.com/13155972/146611507-30ea9eb5-6c6b-41c3-bc0c-677cc0d2c420.png)

Turning the toggle you can now see they are no longer included and the Total tests goes down appropriately.
![Screen Shot 2021-12-17 at 4 43 19 PM](https://user-images.githubusercontent.com/13155972/146611591-83e57333-1126-4c94-80aa-49e9168c3b3b.png)

