### PR TITLE
Move csv check to node-graphql using url-exist dependency (MCS-935).

### DIFF
--- a/analysis-ui/src/components/EvaluationStatus/evalStatusTable.jsx
+++ b/analysis-ui/src/components/EvaluationStatus/evalStatusTable.jsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import { Query } from 'react-apollo';
+import { Query, useQuery } from 'react-apollo';
 import gql from 'graphql-tag';
 import Select from 'react-select';
 import EvalStatusConfigureModal from './evalStatusConfigure';
@@ -10,10 +10,16 @@ const CSV_URL_PREFIX = RESOURCES_URL + "/csv-db-files/Evaluation_";
 const CSV_URL_SCENE_SUFFIX = "_Scenes.csv";
 const CSV_URL_RESULTS_SUFFIX = "_Results.csv";
 const EvaluationStatusQuery = "getEvaluationStatus";
+const getLinkStatusQueryName = "getLinkStatus";
 
 const get_evaluation_status = gql`
     query getEvaluationStatus($eval: String!, $evalName: String!){
         getEvaluationStatus(eval: $eval, evalName: $evalName)
+    }`;
+
+const get_link_status = gql`
+    query getLinkStatus($url: String!){
+        getLinkStatus(url: $url)
     }`;
 
 function ConfigureEval ({statusObj, testTypes, performers, metadatas, updateStatusObjHandler, evalName}) {
@@ -66,11 +72,15 @@ function CreateCSV() {
 }
 
 function CSVDownloadLink({url, linkText}) {
+    const {data, refetch} = useQuery(get_link_status, {variables: {url}, fetchPolicy: 'no-cache'});
     const [linkActive, updateLinkActive] = useState();
+
     useEffect(() => {
         const getUrl = async () => {
-            const linkCheck = await fetch(url);
-            updateLinkActive(linkCheck.ok);
+            refetch({variables: {url}});
+            if(data !== undefined && data[getLinkStatusQueryName] !== undefined) {
+                updateLinkActive(data[getLinkStatusQueryName]);
+            }
         }
         getUrl();
     });

--- a/node-graphql/package.json
+++ b/node-graphql/package.json
@@ -19,6 +19,7 @@
     "lodash": "^4.17.21",
     "mongodb": "^3.7.3",
     "mongoose": "^5.13.14",
-    "nodemailer": "^6.4.16"
+    "nodemailer": "^6.4.16",
+    "url-exist": "^2.0.0"
   }
 }

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -8,6 +8,7 @@ const { createComplexMongoQuery } = require('./server.mongoSyntax');
 const {  historyFieldLabelMap, historyExcludeFields, sceneExcludeFields,  sceneFieldLabelMap, historyIncludeFieldsTable, 
     sceneIncludeFieldsTable, historyFieldLabelMapTable, sceneFieldLabelMapTable } = require('./server.fieldMappings');
 const spawn = require("child_process").spawn;
+const urlExist = require("url-exist");
 
 let complexQueryProjectionObject = null;
 const HISTORY_COLLECTION = "mcs_history";
@@ -121,6 +122,7 @@ const mcsTypeDefs = gql`
     getHistoryCollectionMapping: JSON
     getSceneCollectionMapping: JSON
     getEvalHistory(eval: String, categoryType: String, testNum: Int) : [History]
+    getLinkStatus(url: String): Boolean
     getEval2History(catTypePair: String, testNum: Int) : [History]
     getEval2Scene(testType: String, testNum: Int) : [Scene]
     getEvalScene(eval: String, sceneName: String, testNum: Int) : [Scene]
@@ -167,6 +169,9 @@ const mcsResolvers = {
         msc_eval: async(obj, args, context, infow) => {
             return await mcsDB.db.collection('msc_eval').find({})
                 .toArray().then(result => {return result});
+        },
+        getLinkStatus: async(obj, args, context, infow) => {
+            return await urlExist(args["url"]);
         },
         getEval2History: async(obj, args, context, infow) => {
             // Eval 2


### PR DESCRIPTION
This was to prevent polluting the console with 404-related errors if a csv file hasn't yet been generated. 