### PR TITLE
MCS-1198: Add view to test overview to be able to view by slice and slice levels

### DIFF
--- a/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
+++ b/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
@@ -7,13 +7,14 @@ import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import { default as ReactSelect } from "react-select";
+import { components } from "react-select";
 
 const hyperCubeDataQueryName = "getTestOverviewData";
 const getHyperCubeData = gql`
 
-query getTestOverviewData($eval: String!, $categoryType: String!, $performer: String!, $metadata: String!, $useDidNotAnswer: Boolean!, $weightedPassing: Boolean!, $statType: String!, $sliceLevel: Int!) {
-    getTestOverviewData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata, useDidNotAnswer: $useDidNotAnswer, weightedPassing: $weightedPassing, statType: $statType, sliceLevel: $sliceLevel) 
-
+query getTestOverviewData($eval: String!, $categoryType: String!, $performer: String!, $metadata: String!, $useDidNotAnswer: Boolean!, $weightedPassing: Boolean!, $statType: String!, $sliceLevel: Int!, $sliceType: String!, $sliceKeywords: JSON!) {
+    getTestOverviewData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata, useDidNotAnswer: $useDidNotAnswer, weightedPassing: $weightedPassing, statType: $statType, sliceLevel: $sliceLevel, sliceType: $sliceType, sliceKeywords: $sliceKeywords) 
 }`;
 
 const overViewTableFieldsStatic = [
@@ -32,94 +33,167 @@ const overViewTableFieldsStatic = [
     {"title": "SEM", "key": "standardError"}
 ];
 
+const KeywordSelectOption = (props) => {
+    return (
+        <div>
+            <components.Option {...props}>
+                <input type="checkbox" checked={props.isSelected} onChange={() => null}/>{" "}
+                <label className="keyword-label">{props.label}</label>
+            </components.Option>
+        </div>
+    );
+};
+
+const KeywordEmptyContainer = ({ children, ...props }) => {
+    const { getValue, hasValue } = props;
+    const numberSelected = getValue().length;
+    if (!hasValue) {
+        return (
+            <components.ValueContainer {...props}>
+                {children}
+            </components.ValueContainer>
+        );
+    }
+
+    let newChildren = [`${numberSelected} items selected`];
+    newChildren.push(children[1]);
+    return (
+        <components.ValueContainer {...props}>
+            {newChildren}
+        </components.ValueContainer>
+    );
+};
+
+let hyperCubeData;
+
 class HyperCubeResultsTable extends React.Component {
 
     constructor(props) {
         super(props);
         this.state = {
-            sliceLevel: 1
+            sliceLevel: 1,
+            sliceType: "level",
+            sliceKeywords: []
         }
+
+        this.setKeywords = this.setKeywords.bind(this);
     }
 
     updateSliceLevel(newSliceLevel) {
         this.setState({sliceLevel: newSliceLevel});
     }
 
+    updateSliceViwer(newViewType) {
+        this.setState({"sliceType": newViewType});
+    }
+
+    setKeywords(keywords) {
+        this.setState({"sliceKeywords": keywords});
+    }
+
     render() {
+        const tableTitle = "Overview Stats (" + this.props.state.category + "/" + 
+                this.props.state.performer + "/" + this.props.state.metadata + ")";
+        const notActiveButtonClasses = "btn btn-outline-secondary";
+        const activeButtonClasses = "btn btn-outline-secondary active";
+        let overViewTableFields = [{"title": this.props.hyperCubePivotValue, "key": this.props.hyperCubePivotValue}];
+        overViewTableFields = overViewTableFields.concat(overViewTableFieldsStatic);
+
         return (
-            <Query query={getHyperCubeData} variables={{
-                "eval": this.props.state.eval,
-                "categoryType": this.props.state.category,
-                "performer": this.props.state.performer,
-                "metadata": this.props.state.metadata,
-                "useDidNotAnswer": this.props.state.useDidNotAnswer,
-                "weightedPassing": this.props.state.weightedPassing,
-                "statType": this.props.hyperCubePivotValue,
-                "sliceLevel": this.state.sliceLevel}}>
-            {
-                ({ loading, error, data }) => {
-                    if (loading) return <div>Loading ...</div> 
-                    if (error) return <div>Overview data does not exist for these attributes.</div>
-
-                    const hyperCubeData = data[hyperCubeDataQueryName]["stats"];
-
-                    const tableTitle = "Overview Stats (" + this.props.state.category + "/" + 
-                        this.props.state.performer + "/" + this.props.state.metadata + ")";
-
-                    let overViewTableFields = [{"title": this.props.hyperCubePivotValue, "key": this.props.hyperCubePivotValue}];
-                    overViewTableFields = overViewTableFields.concat(overViewTableFieldsStatic);
-
-                    const notActiveButtonClasses = "btn btn-outline-secondary";
-                    const activeButtonClasses = "btn btn-outline-secondary active";
-
-                    return (
-                        <>
-                            <h4>{tableTitle}</h4>
-                            <div className="overview-results-csv-holder">
-                                <div className="csv-results-child">
-                                    <IconButton onClick={() => {this.props.downloadCSV(hyperCubeData, overViewTableFields, tableTitle)}}>
-                                        <span className="material-icons">
-                                            get_app
-                                        </span>CSV
-                                    </IconButton>
+            <>
+                <h4>{tableTitle}</h4>
+                <div className="overview-results-csv-holder">
+                    <div className="csv-results-child">
+                        <IconButton onClick={() => {this.props.downloadCSV(hyperCubeData, overViewTableFields, tableTitle)}}>
+                            <span className="material-icons">
+                                get_app
+                            </span>CSV
+                        </IconButton>
+                    </div>
+                </div>
+                {this.props.hyperCubePivotValue === "slice" &&
+                    <div className="overview-results-slice-chooser">
+                        <div className="metadata-group btn-group" role="group">
+                            <button className={this.state.sliceType === "level" ? 'btn btn-primary active' : 'btn btn-secondary'} type="button"
+                                    onClick={() => this.updateSliceViwer("level")}>Level</button>
+                            <button className={this.state.sliceType === "keyword" ? 'btn btn-primary active' : 'btn btn-secondary'} type="button"
+                                    onClick={() => this.updateSliceViwer("keyword")}>Keyword</button>
+                        </div>
+                        {this.state.sliceType === "level" &&
+                            <>
+                                <span className="slice-header">Slice level: </span>
+                                <div className="btn-group me-2" role="group">
+                                    {this.props.numberSliceArray.map((sliceNum, key) =>
+                                        <button key={'slice_level_' + key} type="button" className={this.state.sliceLevel === sliceNum ? activeButtonClasses : notActiveButtonClasses} onClick={()=>this.updateSliceLevel(sliceNum)}>{sliceNum}</button>
+                                    )}
                                 </div>
+                            </>
+                        }
+                        {this.state.sliceType === "keyword" &&
+                            <div className="slice-keywords-chooser">
+                                <ReactSelect
+                                    onChange={this.setKeywords}
+                                    options={this.props.sliceKeywords}
+                                    value={this.state.sliceKeywords}
+                                    isMulti
+                                    hideSelectedOptions={false}
+                                    closeMenuOnSelect={false}
+                                    components={{
+                                        Option: KeywordSelectOption,
+                                        ValueContainer: KeywordEmptyContainer
+                                    }}
+                                />
                             </div>
-                            {this.props.hyperCubePivotValue === "slice" &&
-                                <div className="overview-results-slice-chooser">
-                                    <span className="slice-header">Slice level: </span>
-                                    <div className="btn-group me-2" role="group">
-                                        <button type="button" className={this.state.sliceLevel === 1 ? activeButtonClasses : notActiveButtonClasses} onClick={()=>this.updateSliceLevel(1)}>1</button>
-                                        <button type="button" className={this.state.sliceLevel === 2 ? activeButtonClasses : notActiveButtonClasses} onClick={()=>this.updateSliceLevel(2)}>2</button>
-                                        <button type="button" className={this.state.sliceLevel === 3 ? activeButtonClasses : notActiveButtonClasses} onClick={()=>this.updateSliceLevel(3)}>3</button>
-                                        <button type="button" className={this.state.sliceLevel === 4 ? activeButtonClasses : notActiveButtonClasses} onClick={()=>this.updateSliceLevel(4)}>4</button>
-                                    </div>
-                                </div>
-                            }
-                            <Table className="score-table" aria-label="simple table" stickyHeader>
-                                <TableHead>
-                                    <TableRow>
-                                        {overViewTableFields.map((field, key) =>
-                                            <TableCell key={'overfiew_header_cell' + key}>{field.title}</TableCell>
-                                        )}
-                                    </TableRow>
-                                </TableHead>
-                                <TableBody>
-                                    {hyperCubeData.map((hyperCell, hyperKey) =>
-                                        <TableRow key={'hyper_row_' + hyperKey} classes={{ root: 'TableRow'}}>
-                                            {overViewTableFields.map((field, fieldKey) => 
-                                                <TableCell key={'hyper_row_cell_' + hyperKey + fieldKey}>
-                                                    {hyperCell[field["key"]]}
-                                                </TableCell>
+                        }
+                    </div>
+                }
+                <Query query={getHyperCubeData} variables={{
+                    "eval": this.props.state.eval,
+                    "categoryType": this.props.state.category,
+                    "performer": this.props.state.performer,
+                    "metadata": this.props.state.metadata,
+                    "useDidNotAnswer": this.props.state.useDidNotAnswer,
+                    "weightedPassing": this.props.state.weightedPassing,
+                    "statType": this.props.hyperCubePivotValue,
+                    "sliceLevel": this.state.sliceLevel,
+                    "sliceType": this.state.sliceType,
+                    "sliceKeywords": this.state.sliceKeywords }}>
+                {
+                    ({ loading, error, data }) => {
+                        if (loading) return <div>Loading ...</div> 
+                        if (error) return <div>Overview data does not exist for these attributes.</div>
+
+                        hyperCubeData = data[hyperCubeDataQueryName]["stats"];
+
+                        return (
+                            <>
+                                
+                                <Table className="score-table" aria-label="simple table" stickyHeader>
+                                    <TableHead>
+                                        <TableRow>
+                                            {overViewTableFields.map((field, key) =>
+                                                <TableCell key={'overfiew_header_cell' + key}>{field.title}</TableCell>
                                             )}
                                         </TableRow>
-                                    )}
-                                </TableBody>
-                            </Table>
-                        </>
-                    )
+                                    </TableHead>
+                                    <TableBody>
+                                        {hyperCubeData.map((hyperCell, hyperKey) =>
+                                            <TableRow key={'hyper_row_' + hyperKey} classes={{ root: 'TableRow'}}>
+                                                {overViewTableFields.map((field, fieldKey) => 
+                                                    <TableCell key={'hyper_row_cell_' + hyperKey + fieldKey}>
+                                                        {hyperCell[field["key"]]}
+                                                    </TableCell>
+                                                )}
+                                            </TableRow>
+                                        )}
+                                    </TableBody>
+                                </Table>
+                            </>
+                        )
+                    }
                 }
-            }
-            </Query>
+                </Query>
+            </>
         );
     }
 }

--- a/analysis-ui/src/components/TestOverview/overview.jsx
+++ b/analysis-ui/src/components/TestOverview/overview.jsx
@@ -8,10 +8,10 @@ import HyperCubeResultsTable from './hypercubeResultsTable';
 import Switch from "react-switch";
 import ScoreCardTable from './scorecardTable';
 
-const getTestTypeQueryName = "getTestType";
-const getTestType = gql`
-    query getTestType($eval: String!, $categoryType: String!) {
-        getTestType(eval: $eval, categoryType: $categoryType) 
+const getTestTypeQueryName = "getTestTypeOverviewData";
+const getTestTypeOverviewData = gql`
+    query getTestTypeOverviewData($eval: String!, $categoryType: String!) {
+        getTestTypeOverviewData(eval: $eval, categoryType: $categoryType) 
     }`;
 class TestOverview extends React.Component {
 
@@ -106,7 +106,7 @@ class TestOverview extends React.Component {
                     </div>
                     <div className="test-overview-area">
                         {(this.state.eval !== "" && this.state.category !== "") &&
-                            <Query query={getTestType} variables={{
+                            <Query query={getTestTypeOverviewData} variables={{
                                 "eval": this.state.eval,
                                 "categoryType": this.state.category}}>
                             {
@@ -115,6 +115,21 @@ class TestOverview extends React.Component {
                                     if (error) return <div>Overview data does not exist for these attributes.</div>
 
                                 const testType = data[getTestTypeQueryName]["testType"];
+                                const numberSlices = data[getTestTypeQueryName]["sliceNumber"];
+                                const sliceKeywords = data[getTestTypeQueryName]["sliceKeywords"];
+
+                                let numberSliceArray = [];
+                                for(let i=0; i < numberSlices; i++) {
+                                    numberSliceArray[i] = i + 1;
+                                }
+
+                                let sliceKeywordsObjArray = [];
+                                for(let i=0; i < sliceKeywords.length; i++) {
+                                    sliceKeywordsObjArray.push({
+                                        label: sliceKeywords[i],
+                                        value: sliceKeywords[i]
+                                    })
+                                }
 
                                 return(
                                     <>
@@ -162,7 +177,7 @@ class TestOverview extends React.Component {
                                                         <HyperCubeResultsTable state={this.state} downloadCSV={this.downloadCSV} hyperCubePivotValue="hyperCubeID"/>
                                                     }
                                                     {"BySlice" === this.state.currentTab && 
-                                                        <HyperCubeResultsTable state={this.state} downloadCSV={this.downloadCSV} hyperCubePivotValue="slice"/>
+                                                        <HyperCubeResultsTable state={this.state} downloadCSV={this.downloadCSV} hyperCubePivotValue="slice" numberSliceArray={numberSliceArray} sliceKeywords={sliceKeywordsObjArray}/>
                                                     }
                                                     {"Scorecard" === this.state.currentTab && 
                                                         <ScoreCardTable state={this.state} downloadCSV={this.downloadCSV}/>

--- a/analysis-ui/src/components/TestOverview/overview.jsx
+++ b/analysis-ui/src/components/TestOverview/overview.jsx
@@ -1,10 +1,18 @@
 import React from 'react';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
 import EvalNavItem from './evalNavItem';
 import CategoryNavItem from './categoryNavItem';
 import ButtonGroupNavItem from './buttonGroupNavItem';
 import HyperCubeResultsTable from './hypercubeResultsTable';
 import Switch from "react-switch";
+import ScoreCardTable from './scorecardTable';
 
+const getTestTypeQueryName = "getTestType";
+const getTestType = gql`
+    query getTestType($eval: String!, $categoryType: String!) {
+        getTestType(eval: $eval, categoryType: $categoryType) 
+    }`;
 class TestOverview extends React.Component {
 
     constructor(props) {
@@ -15,15 +23,22 @@ class TestOverview extends React.Component {
             performer: "",
             metadata: "",
             useDidNotAnswer: true,
-            weightedPassing: true
+            weightedPassing: true,
+            currentTab: "HyperCubeId"
         }
         this.stateUpdateHandler = this.stateUpdateHandler.bind(this);
         this.toggleUseDidNotAnswer = this.toggleUseDidNotAnswer.bind(this);
         this.toggleWeightedPassing = this.toggleWeightedPassing.bind(this);
+        this.downloadCSV = this.downloadCSV.bind(this);
     }
 
     stateUpdateHandler(key, value) {
-        this.setState({[key]: value});
+        // Reset to default tab if changing Eval or Category
+        if(key === "eval" || key === "category") {
+            this.setState({[key]: value, currentTab: "HyperCubeId"});
+        } else {
+            this.setState({[key]: value});
+        }
     }
 
     toggleUseDidNotAnswer() {
@@ -32,6 +47,39 @@ class TestOverview extends React.Component {
 
     toggleWeightedPassing() {
         this.setState(prevState => ({weightedPassing: !prevState.weightedPassing}));
+    }
+
+    toggleTab(newTabName) {
+        this.setState({currentTab: newTabName});
+    }
+
+    downloadCSV(tableData, tableHeaders, tableTitle) {
+        const columnDelimiter = ',';
+        const rowDelimter = '\n';
+        let csvString = tableTitle + rowDelimter;
+
+        for(let i=0; i < tableHeaders.length; i++) {
+            if(i === tableHeaders.length -1) {
+                csvString += tableHeaders[i].title + rowDelimter;
+            } else {
+                csvString += tableHeaders[i].title + columnDelimiter;
+            }
+        }
+
+        for(let x=0; x < tableData.length; x++) {
+            for(let y=0; y < tableHeaders.length; y++) {
+                if(y === tableHeaders.length -1) {
+                    csvString += tableData[x][tableHeaders[y].key] + rowDelimter;
+                } else {
+                    csvString += tableData[x][tableHeaders[y].key]  + columnDelimiter;
+                }
+            }
+        }
+
+        const downloader = document.createElement('a'); //create a link
+        downloader.setAttribute('href', encodeURI("data:text/csv;charset=utf-8," + csvString)); //content to download
+        downloader.setAttribute('download', `${tableTitle.replaceAll(' ', '-')}.csv`); //filename of download
+        downloader.click(); //download
     }
 
     render() {
@@ -58,34 +106,73 @@ class TestOverview extends React.Component {
                     </div>
                     <div className="test-overview-area">
                         {(this.state.eval !== "" && this.state.category !== "") &&
-                            <>
-                                <div className="overview-button-group-holder">
-                                    <div>
-                                        <ButtonGroupNavItem fieldName="performer" state={this.state} stateUpdateHandler={this.stateUpdateHandler}/>
-                                    </div>
-                                    <div className="overview-buttom-group-right">
-                                        <label className="no-answer-toggle-holder">
-                                            <div className="switch-container">
-                                                <Switch onChange={this.toggleWeightedPassing} checked={this.state.weightedPassing}/>
+                            <Query query={getTestType} variables={{
+                                "eval": this.state.eval,
+                                "categoryType": this.state.category}}>
+                            {
+                                ({ loading, error, data }) => {
+                                    if (loading) return <div>Loading ...</div> 
+                                    if (error) return <div>Overview data does not exist for these attributes.</div>
+
+                                const testType = data[getTestTypeQueryName]["testType"];
+
+                                return(
+                                    <>
+                                        <div className="overview-button-group-holder">
+                                            <div>
+                                                <ButtonGroupNavItem fieldName="performer" state={this.state} stateUpdateHandler={this.stateUpdateHandler}/>
                                             </div>
-                                            <span>Passing/Weighted Scoring</span>
-                                        </label>
-                                        <label className="no-answer-toggle-holder">
-                                            <div className="switch-container">
-                                                <Switch onChange={this.toggleUseDidNotAnswer} checked={this.state.useDidNotAnswer}/>
+                                            <div className="overview-buttom-group-right">
+                                                <label className="no-answer-toggle-holder">
+                                                    <div className="switch-container">
+                                                        <Switch onChange={this.toggleWeightedPassing} checked={this.state.weightedPassing}/>
+                                                    </div>
+                                                    <span>Passing/Weighted Scoring</span>
+                                                </label>
+                                                <label className="no-answer-toggle-holder">
+                                                    <div className="switch-container">
+                                                        <Switch onChange={this.toggleUseDidNotAnswer} checked={this.state.useDidNotAnswer}/>
+                                                    </div>
+                                                    <span>Include No Answers in Calculations</span>
+                                                </label>
+                                                <ButtonGroupNavItem fieldName="metadata" state={this.state} stateUpdateHandler={this.stateUpdateHandler}/>
                                             </div>
-                                            <span>Include No Answers in Calculations</span>
-                                        </label>
-                                        <ButtonGroupNavItem fieldName="metadata" state={this.state} stateUpdateHandler={this.stateUpdateHandler}/>
-                                    </div>
-                                </div>
-                                
-                                {(this.state.performer !== "" && this.state.metadata !== "") &&
-                                    <div className="overview-table-container">
-                                        <HyperCubeResultsTable state={this.state}/>
-                                    </div>
-                                }
-                            </>
+                                        </div>
+                                        
+                                        {(this.state.performer !== "" && this.state.metadata !== "") &&
+                                            <>
+                                                <ul className="nav nav-tabs">
+                                                    <li className="nav-item" >
+                                                        <button className={"HyperCubeId" === this.state.currentTab ? 'nav-link overview-nav-link active' : 'nav-link overview-nav-link'} onClick={() => this.toggleTab("HyperCubeId")}>Hyper Cube ID</button>
+                                                    </li>
+                                                    {testType !== 'agents' &&
+                                                        <li className="nav-item" >
+                                                            <button className={"BySlice" === this.state.currentTab ? 'nav-link overview-nav-link active' : 'nav-link overview-nav-link'} onClick={() => this.toggleTab("BySlice")}>By Slice</button>
+                                                        </li>
+                                                    }
+                                                    {/* Exclude Evaluation 3 Results because we didn't have scorecard functionality yet */}
+                                                    {((testType === "interactive" || testType === 'retrieval') && this.props.state.eval !== "eval_3_results")  &&
+                                                        <li className="nav-item" >
+                                                            <button className={"Scorecard" === this.state.currentTab ? 'nav-link overview-nav-link active' : 'nav-link overview-nav-link'} onClick={() => this.toggleTab("Scorecard")}>Scorecard</button>
+                                                        </li>
+                                                    }
+                                                </ul>
+                                                <div className="overview-table-container">
+                                                    {"HyperCubeId" === this.state.currentTab && 
+                                                        <HyperCubeResultsTable state={this.state} downloadCSV={this.downloadCSV} hyperCubePivotValue="hyperCubeID"/>
+                                                    }
+                                                    {"BySlice" === this.state.currentTab && 
+                                                        <HyperCubeResultsTable state={this.state} downloadCSV={this.downloadCSV} hyperCubePivotValue="slice"/>
+                                                    }
+                                                    {"Scorecard" === this.state.currentTab && 
+                                                        <ScoreCardTable state={this.state} downloadCSV={this.downloadCSV}/>
+                                                    }
+                                                </div>
+                                            </>
+                                        }
+                                    </>
+                                )}
+                            }</Query>
                         }
                     </div>
                 </div>

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -267,6 +267,10 @@ ol, ul {
     padding: 20px;
 }
 
+/* .score-table {
+    background-color: white;
+} */
+
 .performer-group, .metadata-group, .score-table-div, .scene-group, .scene-table-div {
     display: flex;
     margin: 5px 10px 10px 10px;
@@ -1450,8 +1454,20 @@ nav.MuiList-root.nav-list.MuiList-padding {
     margin-left: 10px;
 }
 
-.scorecard-holder {
-    margin-top: 40px;
+.overview-nav-link {
+    margin-right: 5px;
+}
+
+.overview-table-container {
+    background-color: white;
+    padding: 15px;
+    border-left: 1px solid #dee2e6;
+    border-bottom: 1px solid #dee2e6;
+    border-right: 1px solid #dee2e6;
+}
+
+.overview-table-container .MuiTableCell-stickyHeader{
+    background-color: white;
 }
 
 .single-scorecard-item {
@@ -1480,6 +1496,20 @@ nav.MuiList-root.nav-list.MuiList-padding {
     position: relative;
     top: -50px;
     z-index: 3;
+}
+
+.overview-results-slice-chooser {
+    height: 5px;
+    float: right;
+    position: relative;
+    top: -35px;
+    z-index: 4;
+    margin-right:25px;
+}
+
+.slice-header {
+    font-weight: bold;
+    padding-right: 8px;
 }
 
 .no-answer-toggle-holder {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -267,10 +267,6 @@ ol, ul {
     padding: 20px;
 }
 
-/* .score-table {
-    background-color: white;
-} */
-
 .performer-group, .metadata-group, .score-table-div, .scene-group, .scene-table-div {
     display: flex;
     margin: 5px 10px 10px 10px;

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -279,6 +279,16 @@ ol, ul {
     max-height: 295px;
 }
 
+.slice-keywords-chooser {
+    display: inline-block;
+    position: relative;
+    width: 350px;
+}
+
+.keyword-label {
+    font-size: 12px;
+}
+
 .score-table-div .table, .object-contents .table {
     border: 1px solid black;
     padding: 5px 15px 5px 15px; 

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -146,8 +146,9 @@ const mcsTypeDefs = gql`
     getEvalTestTypes(eval: String): JSON
     getHomeChartOptions(eval: String, evalType: String): JSON
     getHomeChart(eval: String, evalType: String, isPercent: Boolean, metadata: String, isPlausibility: Boolean, isNovelty: Boolean, isWeighted: Boolean, useDidNotAnswer: Boolean): JSON
-    getTestOverviewData(eval: String, categoryType: String, performer: String, metadata: String, useDidNotAnswer: Boolean, weightedPassing: Boolean): JSON
+    getTestOverviewData(eval: String, categoryType: String, performer: String, metadata: String, useDidNotAnswer: Boolean, weightedPassing: Boolean, statType: String, sliceLevel: Int): JSON
     getScoreCardData(eval: String, categoryType: String, performer: String, metadata: String): JSON
+    getTestType(eval: String, categoryType: String): JSON
   }
 
   type Mutation {
@@ -240,6 +241,13 @@ const mcsResolvers = {
         getEvalByTest: async(obj, args, context, infow) => {
             return await mcsDB.db.collection('msc_eval').find({'test': args["test"]})
                 .toArray().then(result => {return result});
+        },
+        getTestType: async(obj, args, context, infow) => {
+            let result = await mcsDB.db.collection(args.eval).findOne({'category_type': args["categoryType"]});
+
+            return {
+                "testType": result.test_type
+            };
         },
         getEvalByBlock: async(obj, args, context, infow) => {
             return await mcsDB.db.collection('msc_eval').find({'block': args["block"]})
@@ -530,7 +538,6 @@ const mcsResolvers = {
 
             const projectObject = {
                 "correct": "$score.score",
-                "hypercube_id": "$scene_goal_id",
                 "groundTruth": "$score.ground_truth",
                 "testType": "$test_type",
                 "description": "$score.score_description"
@@ -542,6 +549,12 @@ const mcsResolvers = {
                 projectObject["scoreWorth"] = {"$literal": 1};
             }
 
+            if(args.statType === "hyperCubeID") {
+                projectObject["hypercube_id"] = "$scene_goal_id";
+            } else if(args.statType === "slice") {
+                projectObject["slices"] = "$slices";
+            }
+
             if(args.categoryType.toLowerCase().indexOf("agents") > -1) {
                 projectObject["hypercube_id"] = "$category_type"
             }
@@ -550,7 +563,11 @@ const mcsResolvers = {
                 {"$match": searchObject}, {"$group": {"_id": projectObject, "count": {"$sum": 1}}
             }]).toArray();
 
-            return processHyperCubeStats(hypercubeStats, args.useDidNotAnswer);
+            if(args.statType === "hyperCubeID") {
+                return processHyperCubeStats(hypercubeStats, args.useDidNotAnswer, "hypercube_id", "hyperCubeID", null);
+            } else {
+                return processHyperCubeStats(hypercubeStats, args.useDidNotAnswer, "slices", "slice", args.sliceLevel);
+            }
         },
         getScoreCardData: async(obj, args, context, infow) =>{
             const searchObject = {

--- a/node-graphql/server.statsFunctions.js
+++ b/node-graphql/server.statsFunctions.js
@@ -382,17 +382,40 @@ function updateStatObj(hyperCubeObj, statObj) {
     }
 }
 
-function processHyperCubeStats(hyperCubeProjection, includeDoNotAnswer) {
+function processStatNameField(statName, sliceLevel) {
+    if(Array.isArray(statName)) {
+        let statStr = "";
+
+        // Using sliceLevel to limit the number of items shown in the slice and will combine things to higher levels
+        let sliceArrayLength = statName.length;
+        if(sliceLevel < sliceArrayLength) {
+            sliceArrayLength = sliceLevel;
+        }
+
+        for(let i=0; i < sliceArrayLength; i++) {
+            statStr += statName[i];
+
+            if(i < sliceArrayLength -1) {
+                statStr += ", ";
+            }
+        }
+
+        return statStr;
+    } else {
+        return statName;
+    }
+}
+
+function processHyperCubeStats(hyperCubeProjection, includeDoNotAnswer, statId, statName, sliceLevel) {
     let statArray = [];
     let testType = hyperCubeProjection[0]["_id"]["testType"];
 
     for(let i = 0; i < hyperCubeProjection.length; i++) {
-        let statObj = statArray.find(element => element.hyperCubeID === hyperCubeProjection[i]["_id"]["hypercube_id"]);
+        let statObj = statArray.find(element => element[statName] === processStatNameField(hyperCubeProjection[i]["_id"][statId], sliceLevel));
         if(statObj !== undefined) {
             updateStatObj(hyperCubeProjection[i], statObj);
         } else {
             let newStatObj = {
-                "hyperCubeID": hyperCubeProjection[i]["_id"]["hypercube_id"],
                 "correct_plausible": 0,
                 "correct_implausible": 0,
                 "incorrect_plausible": 0,
@@ -400,15 +423,15 @@ function processHyperCubeStats(hyperCubeProjection, includeDoNotAnswer) {
                 "did_not_answer_plausible": 0,
                 "did_not_answer_implausible": 0
             };
+            newStatObj[statName] = processStatNameField(hyperCubeProjection[i]["_id"][statId], sliceLevel);
             updateStatObj(hyperCubeProjection[i], newStatObj);
             statArray.push(newStatObj);
         }
     }
 
-    statArray.sort((a, b) => (a.hyperCubeID > b.hyperCubeID) ? 1 : -1);
+    statArray.sort((a, b) => (a[statName] > b[statName]) ? 1 : -1);
 
     let totalStatObj = {
-        "hyperCubeID": "Totals",
         "correct_plausible": 0,
         "correct_implausible": 0,
         "incorrect_plausible": 0,
@@ -416,6 +439,8 @@ function processHyperCubeStats(hyperCubeProjection, includeDoNotAnswer) {
         "did_not_answer_plausible": 0,
         "did_not_answer_implausible": 0
     };
+    totalStatObj[statName] = "Totals";
+
     for(let j = 0; j < statArray.length; j++) {
         totalStatObj["correct_plausible"] += statArray[j]["correct_plausible"];
         totalStatObj["correct_implausible"] += statArray[j]["correct_implausible"];


### PR DESCRIPTION
Modified Test Overview to have tabs for cube id/slice/scorecard - only show tab and table if applicable to that test/category type.  Made it so on the slice view, you can view by slice levels.