### PR TITLE
Load Query Redesign

### DIFF
--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -35,9 +35,9 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
     const [search, setSearch] = useState("");
     const [selectedQueries, setSelectedQueries] = useState([]);
 
-    const loadQuery = (query) => {
-        loadQueryHandler(query);
-        onHide();
+    const loadQuery = () => {
+        let queries = selectedQueries
+        loadQueryHandler(queries);
     }
 
     const closeModal = () => {
@@ -103,7 +103,7 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                                 <LoadQuerySearchBar setSearch={setSearch}/>
                                 <span>
                                     <p>({selectedQueries.length}) Selected</p>
-                                    <button type="button" onClick={() => loadQuery("")}>Load Selected</button>
+                                    <button type="button" onClick={() => loadQuery()}>Load Selected</button>
                                 </span>
                             </div>
                             <table className="load-query-table">

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -64,18 +64,8 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
     }
 
     useEffect(() => {
-        let checkbox = document.getElementById('header_checkbox');
-        if (checkbox !== null)
-            checkbox.checked = selectedQueries.length > 0;
-    }, [selectedQueries])
-
-    useEffect(() => {
         updateSelectedBasedOnSearch();
-    }, [search])
-
-    useEffect(() => {
-        updateSelectedBasedOnSearch();
-    }, [activeTab])
+    }, [search, activeTab])
 
     const setSelected = (key, button) => {
         const checkbox = document.getElementById('load_query_checkbox_' + key);
@@ -153,7 +143,7 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                                         <th style={{columnWidth: '1vw'}}>
                                             <a href='#' data-toggle="tooltip" title="Checking this box will select all of the queries matching the search parameters. 
                                             If there are no search parameters, all queries will be selected. Unchecking this box will clear all selections.">
-                                                <input type="checkbox" id="header_checkbox" onClick={(e) => selectOrClearAll(e)}/>
+                                                <input type="checkbox" id="header_checkbox" checked={selectedQueries.length > 0} onClick={(e) => selectOrClearAll(e)}/>
                                             </a>
                                         </th>
                                         <th style={{columnWidth: '50vw'}}>Title</th>

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -1,5 +1,4 @@
-import React, {useState, useEffect} from 'react';
-import Modal from 'react-bootstrap/Modal';
+import React, {useState} from 'react';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 
@@ -47,57 +46,16 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
             setSelectedQueries([...selectedQueries, {'query': query, 'key': key}]);
     }
 
-    const updateSelectedBasedOnSearch = () => {
-        let checkboxes = document.getElementsByClassName('load-query-checkbox');
-        for (let i = 0; i < checkboxes.length; i++) {
-            let row = checkboxes[i].parentNode.parentNode;
-            for(let j = 0; j<selectedQueries.length; j++) {
-                let key = parseInt(row.getAttribute('id').replace('load_query_row_', ''));
-                if (key == selectedQueries[j].key) {
-                    if (!row.className.includes('selected-row') && !checkboxes[i].checked) {
-                        row.classList.toggle('selected-row');
-                        checkboxes[i].checked = true;
-                    }
-                }
-            }
-        }
-    }
-
-    useEffect(() => {
-        updateSelectedBasedOnSearch();
-    }, [search, activeTab])
-
-    const setSelected = (key, button) => {
-        const checkbox = document.getElementById('load_query_checkbox_' + key);
-        checkbox.checked = !checkbox.checked;
-        if (!button) {
-            const row = document.getElementById('load_query_row_' + key);
-            let query = JSON.parse(row.getAttribute('query'));
-            row.classList.toggle('selected-row');
-            manageSelectedQueries(query, key, !checkbox.checked)
-        }
-    }
-
     const selectOrClearAll = (e) => {
         let checkboxes = document.getElementsByClassName('load-query-checkbox');
         let clearAll = !e.target.checked
-        if (clearAll) {
-            for (let i=0; i<checkboxes.length; i++) {
-                checkboxes[i].checked = false;
-                let row = checkboxes[i].parentNode.parentNode;
-                if (row.className.includes('selected-row')) {
-                    row.classList.toggle('selected-row');
-                }
-            }
+        if (clearAll)
             setSelectedQueries([]);
-        }
         else {
             let selected = []
             for (let i=0; i<checkboxes.length; i++) {
                 if (!checkboxes[i].checked) {
-                    checkboxes[i].checked = true;
                     let row = checkboxes[i].parentNode.parentNode;
-                    row.classList.toggle('selected-row');
                     let query = JSON.parse(row.getAttribute('query'));
                     let key = parseInt(row.getAttribute('id').replace('load_query_row_', ''));
                     selected.push({'query': query, 'key': key})
@@ -105,6 +63,10 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
             }
             setSelectedQueries([...selectedQueries, ...selected])
         }
+    }
+
+    const isSelected = (key) => {
+        return selectedQueries.some((element) => element.key == key)
     }
 
     return (
@@ -161,9 +123,10 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                                         (query.name.toLowerCase().includes(search.toLowerCase()) || 
                                         query.description.toLowerCase().includes(search.toLowerCase()) || 
                                         query.user.username.toLowerCase().includes(search.toLowerCase()))) &&
-                                        <tr key={'load_query_row_' + key} id={'load_query_row_' + key} onClick={() => setSelected(key, false)} query={JSON.stringify(query)}>
+                                        <tr key={'load_query_row_' + key} id={'load_query_row_' + key} className={isSelected(key) ? 'selected-row' : ''}
+                                            onClick={() => manageSelectedQueries(query, key, isSelected(key))} query={JSON.stringify(query)}>
                                             <td>
-                                                <input type="checkbox" className='load-query-checkbox' id={'load_query_checkbox_' + key} onClick={() => setSelected(key, true)}/>
+                                                <input type="checkbox" className='load-query-checkbox' checked={isSelected(key)}/>
                                             </td>
                                             <td>{query.name}</td>
                                             <td>{(new Date(query.createdDate)).toLocaleString()}</td>

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -145,7 +145,7 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                                 <LoadQuerySearchBar setSearch={setSearch}/>
                                 <span>
                                     <a href='#selected' data-toggle="tooltip" 
-                                    title='Selecting one query will replace the current query tab. Selecting more than one query will append mutiple queries to the end of the tab list.'>({selectedQueries.length}) Selected</a>
+                                    title='Selecting one query will replace the current query tab. Selecting more than one query will append multiple queries to the end of the tab list.'>({selectedQueries.length}) Selected</a>
                                     <button type="button" onClick={() => loadQuery()}>Load Selected</button>
                                 </span>
                             </div>

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -102,18 +102,18 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                             <table className="load-query-table">
                                 <thead>
                                     <tr>
-                                        <th style={{columnWidth: '1vw'}}>
+                                        <th className='header-checkbox'>
                                             <a href='#' data-toggle="tooltip" title="Checking this box will select all of the queries matching the search parameters. 
                                             If there are no search parameters, all queries will be selected. Unchecking this box will clear all selections.">
                                                 <input type="checkbox" id="header_checkbox" checked={selectedQueries.length > 0} onClick={(e) => selectOrClearAll(e)}/>
                                             </a>
                                         </th>
-                                        <th style={{columnWidth: '50vw'}}>Title</th>
-                                        <th style={{columnWidth: '10vw'}}>Date</th>
+                                        <th className='name'>Title</th>
+                                        <th className='date'>Date</th>
                                         {activeTab === 'load_all_queries' &&
-                                            <th style={{columnWidth: '1vw'}}>User</th>
+                                            <th className='user'>User</th>
                                         }
-                                        <th style={{columnWidth: '28vw'}}>Comment</th>
+                                        <th className='comment'>Comment</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import Modal from 'react-bootstrap/Modal';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
@@ -30,9 +30,10 @@ function LoadQuerySearchBar({setSearch}) {
     )
 }
     
-function LoadQueryModal({show, onHide, currentUser, loadQueryHandler}) {
-    const [activeTab, setActiveTab] = useState("load_my_queries");
+function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
+    const [activeTab, setActiveTab] = useState("load_all_queries");
     const [search, setSearch] = useState("");
+    const [selectedQueries, setSelectedQueries] = useState([]);
 
     const loadQuery = (query) => {
         loadQueryHandler(query);
@@ -44,100 +45,116 @@ function LoadQueryModal({show, onHide, currentUser, loadQueryHandler}) {
         onHide();
     }
 
-    return (
-        <Modal show={show} onHide={closeModal} size="lg" aria-labelledby="contained-modal-title-vcenter" contentClassName="load-query-modal" centered>
-            <Modal.Header closeButton>
-                <Modal.Title id="contained-modal-title-vcenter-load">Load Query</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-                <Query query={LOAD_SAVED_QUERIES}  fetchPolicy={'network-only'}>
-                {
-                    ({ loading, error, data }) => {
-                        if (loading) return <div>Loading ...</div> 
-                        if (error) return <div>Error</div>
-                        
-                        let queries = data[getSavedQueriesName];
-                        if(activeTab === 'load_my_queries') {
-                            queries = queries.filter(query => query.user.id === currentUser.id)
-                        }
-                        queries.sort(function(a, b){return b.createdDate - a.createdDate});
+    const manageSelectedQueries = (query, remove) => {
+        let length = selectedQueries.length
+        if (remove) {
+            length -= 1
+            setSelectedQueries(selectedQueries.filter(item => item.name !== query.name && item.createdDate !== query.createdDate));
+        }
+        else {
+            length += 1
+            setSelectedQueries([...selectedQueries, query]);
+        }
+        const checkbox = document.getElementById('header_checkbox') 
+        checkbox.checked = length > 0
+        
+    }
 
-                        return (
-                            <div className="load-query-contents">
-                                <div className="load-query-nav">
-                                    <LoadQuerySearchBar setSearch={setSearch}/>
-                                    <ul className="nav nav-tabs">
-                                        <li className="nav-item">
-                                            <button id={'load_my_queries'} className={'load_my_queries' === activeTab ? 'nav-link active' : 'nav-link'} onClick={() => setActiveTab('load_my_queries')}>My Queries</button>
-                                        </li>
-                                        <li className="nav-item">
-                                            <button id={'load_all_queries'} className={'load_all_queries' === activeTab ? 'nav-link active' : 'nav-link'} onClick={() => setActiveTab('load_all_queries')}>All Queries</button>
-                                        </li>
-                                    </ul>
-                                </div>
-                                <div className="query-tab-contents saved-query-table">
-                                    <table>
-                                        <thead>
-                                            <tr>
-                                                <th>Date</th>
-                                                <th>Name</th>
-                                                <th>Description</th>
-                                                {activeTab === 'load_all_queries' &&
-                                                    <th>User</th>
-                                                }
-                                                <th></th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {queries.map((query, key) =>
-                                                (search === "" ||
-                                                (query.name.toLowerCase().includes(search.toLowerCase()) || 
-                                                query.description.toLowerCase().includes(search.toLowerCase()) || 
-                                                query.user.username.toLowerCase().includes(search.toLowerCase()))) &&
-                                                <tr key={'saved_query_row_' + key}>
-                                                    <td>{(new Date(query.createdDate)).toLocaleString()}</td>
-                                                    <td>{query.name}</td>
-                                                    <td>{query.description}</td>
-                                                    {activeTab === 'load_all_queries' &&
-                                                        <td>{query.user.username}</td>
-                                                    }
-                                                    <td>
-                                                        <button type="button" className="btn btn-secondary btn-sm" onClick={() => loadQuery(query)}>Load</button>
-                                                    </td>
-                                                </tr>
-                                            )}
-                                        </tbody>
-                                    </table>
-                                </div>   
-                            </div>
-                        )
+    /////////////////////////////////////////////
+    useEffect(() => {
+        console.log(selectedQueries)
+    }, [selectedQueries]);
+    ////////////////////////////////////////////
+
+    const setSelected = (key, query, button) => {
+        const checkbox = document.getElementById('load_query_checkbox_' + key);
+        checkbox.checked = !checkbox.checked;
+        if (!button) {
+            const row = document.getElementById('load_query_row_' + key);
+            row.classList.toggle('selected-row');
+            manageSelectedQueries(query, !checkbox.checked)
+        }
+    }
+
+    return (
+        <div>
+            <Query query={LOAD_SAVED_QUERIES}  fetchPolicy={'network-only'}>
+            {
+                ({ loading, error, data }) => {
+                    if (loading) return <div>Loading ...</div> 
+                    if (error) return <div>Error</div>
+                    
+                    let queries = data[getSavedQueriesName];
+                    if(activeTab === 'load_my_queries') {
+                        queries = queries.filter(query => query.user.id === currentUser.id)
                     }
+                    queries.sort(function(a, b){return b.createdDate - a.createdDate});
+
+                    return (
+                        <div className="load-query-contents">
+                            <header className='load-query-header'>Load Query</header>
+                            <div className="load-query-nav">
+                                <span>
+                                    <button id={'load_all_queries'} className={'load_all_queries' === activeTab ? 'selected' : ''} onClick={e => setActiveTab('load_all_queries')}>All Queries</button>
+                                    <button id={'load_my_queries'} className={'load_my_queries' === activeTab ? 'selected' : ''} onClick={e => setActiveTab('load_my_queries')}>My Queries</button>
+                                </span>
+                            </div>
+                            <div className="load-query-search-load-line">
+                                <LoadQuerySearchBar setSearch={setSearch}/>
+                                <span>
+                                    <p>({selectedQueries.length}) Selected</p>
+                                    <button type="button" onClick={() => loadQuery("")}>Load Selected</button>
+                                </span>
+                            </div>
+                            <table className="load-query-table">
+                                <thead>
+                                    <tr>
+                                        <th style={{columnWidth: '1vw'}}>
+                                            <input type="checkbox" id="header_checkbox"/>
+                                        </th>
+                                        <th style={{columnWidth: '50vw'}}>Title</th>
+                                        <th style={{columnWidth: '10vw'}}>Date</th>
+                                        {activeTab === 'load_all_queries' &&
+                                            <th style={{columnWidth: '1vw'}}>User</th>
+                                        }
+                                        <th style={{columnWidth: '30vw'}}>Comment</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {queries.map((query, key) =>
+                                        (search === "" ||
+                                        (query.name.toLowerCase().includes(search.toLowerCase()) || 
+                                        query.description.toLowerCase().includes(search.toLowerCase()) || 
+                                        query.user.username.toLowerCase().includes(search.toLowerCase()))) &&
+                                        <tr key={'load_query_row_' + key} id={'load_query_row_' + key} onClick={() => setSelected(key, query, false)}>
+                                            <td>
+                                                <input type="checkbox" className='load-query-checkbox' id={'load_query_checkbox_' + key} onClick={() => setSelected(key, query, true)}/>
+                                            </td>
+                                            <td>{query.name}</td>
+                                            <td>{(new Date(query.createdDate)).toLocaleString()}</td>
+                                            {activeTab === 'load_all_queries' &&
+                                                <td>{query.user.username}</td>
+                                            }
+                                            <td>{query.description}</td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    )
                 }
-                </Query>
-            </Modal.Body>
-        </Modal>
+            }
+            </Query>
+        </div>
     );
 }
 
 function LoadQuery ({currentUser, loadQueryHandler}) {
-
-    const [modalShow, setModalShow] = React.useState(false);
-
     return (
-        <>
-            <a href="#loadQueryLink" onClick={() => setModalShow(true)} className="icon-link">
-                <span className="material-icons icon-margin-right">
-                    folder_open
-                </span>
-            </a>
-
-            <LoadQueryModal
-                show = {modalShow}
-                onHide = {() => setModalShow(false)}
-                currentUser = {currentUser}
-                loadQueryHandler = {loadQueryHandler}
-            />
-        </>
+        <LoadQueryPage
+            currentUser = {currentUser}
+            loadQueryHandler = {loadQueryHandler}
+        />
     );
     
 }

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -41,18 +41,10 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
     }
 
     const manageSelectedQueries = (query, key, remove) => {
-        let length = selectedQueries.length
-        if (remove) {
-            length -= 1
+        if (remove)
             setSelectedQueries(selectedQueries.filter(item => key != item.key));
-        }
-        else {
-            length += 1
+        else
             setSelectedQueries([...selectedQueries, {'query': query, 'key': key}]);
-        }
-        const checkbox = document.getElementById('header_checkbox') 
-        checkbox.checked = length > 0
-        
     }
 
     const updateSelectedBasedOnSearch = () => {
@@ -70,6 +62,12 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
             }
         }
     }
+
+    useEffect(() => {
+        let checkbox = document.getElementById('header_checkbox');
+        if (checkbox !== null)
+            checkbox.checked = selectedQueries.length > 0;
+    }, [selectedQueries])
 
     useEffect(() => {
         updateSelectedBasedOnSearch();

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -36,34 +36,53 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
     const [selectedQueries, setSelectedQueries] = useState([]);
 
     const loadQuery = () => {
-        let queries = selectedQueries
+        let queries = selectedQueries;
         loadQueryHandler(queries);
     }
 
-    const closeModal = () => {
-        setSearch("");
-        onHide();
-    }
-
-    const manageSelectedQueries = (query, remove) => {
+    const manageSelectedQueries = (query, key, remove) => {
         let length = selectedQueries.length
         if (remove) {
             length -= 1
-            setSelectedQueries(selectedQueries.filter(item => item.name !== query.name && item.createdDate !== query.createdDate));
+            setSelectedQueries(selectedQueries.filter(item => key != item.key));
         }
         else {
             length += 1
-            setSelectedQueries([...selectedQueries, query]);
+            setSelectedQueries([...selectedQueries, {'query': query, 'key': key}]);
         }
         const checkbox = document.getElementById('header_checkbox') 
         checkbox.checked = length > 0
         
     }
 
+    const updateSelectedBasedOnSearch = () => {
+        let checkboxes = document.getElementsByClassName('load-query-checkbox');
+        for (let i = 0; i < checkboxes.length; i++) {
+            let row = checkboxes[i].parentNode.parentNode;
+            for(let j = 0; j<selectedQueries.length; j++) {
+                let key = parseInt(row.getAttribute('id').replace('load_query_row_', ''));
+                if (key == selectedQueries[j].key) {
+                    if (!row.className.includes('selected-row') && !checkboxes[i].checked) {
+                        row.classList.toggle('selected-row');
+                        checkboxes[i].checked = true;
+                    }
+                }
+            }
+        }
+    }
+
     /////////////////////////////////////////////
     useEffect(() => {
         console.log(selectedQueries)
     }, [selectedQueries]);
+
+    useEffect(() => {
+        updateSelectedBasedOnSearch();
+    }, [search])
+
+    useEffect(() => {
+        updateSelectedBasedOnSearch();
+    }, [activeTab])
     ////////////////////////////////////////////
 
     const setSelected = (key, query, button) => {
@@ -72,7 +91,31 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
         if (!button) {
             const row = document.getElementById('load_query_row_' + key);
             row.classList.toggle('selected-row');
-            manageSelectedQueries(query, !checkbox.checked)
+            manageSelectedQueries(query, key, !checkbox.checked)
+        }
+    }
+
+    const clearOrSelectAll = (e) => {
+        let clearAll = !e.target.checked
+        console.log(e.target.checked)
+        let checkboxes = document.getElementsByClassName('load-query-checkbox');
+        if (clearAll) {
+            for (let i=0; i<checkboxes.length; i++) {
+                checkboxes[i].checked = false;
+                let row = checkboxes[i].parentNode.parentNode;
+                if (row.className.includes('selected-row')) {
+                    row.classList.toggle('selected-row');
+                }
+            }
+            setSelectedQueries([]);
+        }
+        else {
+            for (let i=0; i<checkboxes.length; i++) {
+                checkboxes[i].checked = true;
+                let row = checkboxes[i].parentNode.parentNode;
+                row.classList.toggle('selected-row');
+            }
+            setSelectedQueries([]);
         }
     }
 
@@ -110,14 +153,14 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                                 <thead>
                                     <tr>
                                         <th style={{columnWidth: '1vw'}}>
-                                            <input type="checkbox" id="header_checkbox"/>
+                                            <input type="checkbox" id="header_checkbox" onClick={(e) => clearOrSelectAll(e)}/>
                                         </th>
                                         <th style={{columnWidth: '50vw'}}>Title</th>
                                         <th style={{columnWidth: '10vw'}}>Date</th>
                                         {activeTab === 'load_all_queries' &&
                                             <th style={{columnWidth: '1vw'}}>User</th>
                                         }
-                                        <th style={{columnWidth: '30vw'}}>Comment</th>
+                                        <th style={{columnWidth: '28vw'}}>Comment</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/analysis-ui/src/components/QueryBuilder/queryPage.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryPage.jsx
@@ -167,7 +167,13 @@ class QueryPage extends React.Component {
         this.setState({ 
             showLoadQuery: !this.state.showLoadQuery
         });
-        document.getElementById('load_query_icon').classList.toggle('selected')
+        document.getElementById('load_query_icon').classList.toggle('selected');
+        let a = document.getElementsByClassName("nav-link active")
+        console.log(a)
+        for (let i=0; i<a.length; i++) {
+            a[i].className = ('nav-link load-query-active');
+            console.log(a[i])
+        }
     }
 
     render() {

--- a/analysis-ui/src/components/QueryBuilder/queryPage.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryPage.jsx
@@ -18,7 +18,8 @@ class QueryPage extends React.Component {
             }],
             currentTab: 1,
             totalTab: 1,
-            currentTabMongoId: ""
+            currentTabMongoId: "",
+            showLoadQuery: false
         };
 
         this.queryResultsTableRef = React.createRef();
@@ -162,6 +163,13 @@ class QueryPage extends React.Component {
         this.updateQueryState(newArray, newCurrentTab);
     }
 
+    showLoadQuery = () => {
+        this.setState({ 
+            showLoadQuery: !this.state.showLoadQuery
+        });
+        document.getElementById('load_query_icon').classList.toggle('selected')
+    }
+
     render() {
         return (
             <div className="query-page-contents">
@@ -174,16 +182,23 @@ class QueryPage extends React.Component {
                         )}
                     </ul>
                     <div className="query-tab-controls">
-                        <a href="#addTab" onClick={this.addTab} className="icon-link">
-                            <span className="material-icons icon-margin-right">
-                                add
-                            </span>
-                        </a>
-                        <LoadQuery currentUser={this.props.currentUser} loadQueryHandler={this.loadQueryHandler}/>
+                        <span className="query-tab-controls-span">
+                            <a href="#addTab" onClick={this.addTab} className="icon-link">
+                                <span className="material-icons icon-margin-right">
+                                    add
+                                </span>
+                            </a>
+                            <button id={'load_query_icon'} onClick={() => this.showLoadQuery()}>
+                                <span className="material-icons icon-margin-center">
+                                    folder_open
+                                </span>
+                            </button>
+                        </span>
                     </div>
                 </div>
                 <div className="query-tab-contents">
-                    {this.state.queryTabs.map((tabObj, key) => 
+                    {this.state.showLoadQuery && <LoadQuery currentUser={this.props.currentUser} loadQueryHandler={this.loadQueryHandler}/>}
+                    {!this.state.showLoadQuery && this.state.queryTabs.map((tabObj, key) => 
                         <div key={'query_tab_' + key} className={tabObj.id === this.state.currentTab ? null : 'd-none'}>
                             <ComplexQueryBuilder queryId={tabObj.id} saveQueryObject={tabObj.tabQueryObj} currentUser={this.props.currentUser} 
                                 updateQueryNameHandler={this.updateQueryNameHandler} updateQueryObjForTab={this.updateQueryObjForTab} numberTabs={this.state.queryTabs.length}

--- a/analysis-ui/src/components/QueryBuilder/queryPage.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryPage.jsx
@@ -68,39 +68,22 @@ class QueryPage extends React.Component {
         }
         let newArray = this.state.queryTabs.concat(additionalTabs);
 
-        await new Promise(resolve => {
-            this.setState({ 
-                totalTab: newArray.length, 
-                queryTabs: newArray
-            }, () => {
-                this.props.currentUser["queryBuilderState"] = this.state;
-                resolve()
-            })
+        this.setState({ 
+            totalTab: newArray.length, 
+            queryTabs: newArray,
+            currentTab: newArray.length - queryObjects.length + 1
         });
-
-        return new Promise(resolve => {
-            this.setState({ 
-                currentTab: newArray.length - queryObjects.length + 1, 
-            }, () => {
-                this.props.currentUser["queryBuilderState"] = this.state;
-                resolve()
-            })
-        });
-
+        this.props.currentUser["queryBuilderState"] = this.state;
     }
 
     updateQueryState = (newArray, newCurrentTab) => {
         newCurrentTab = newCurrentTab !== undefined && newCurrentTab !== null ? newCurrentTab : this.state.currentTab;
-        return new Promise(resolve => {
-            this.setState({ 
-                queryTabs: newArray,
-                currentTab: newCurrentTab,
-                currentTabMongoId: newArray[newCurrentTab-1].mongoId
-            }, () => {
-                this.props.currentUser["queryBuilderState"] = this.state;
-                resolve();
-            })
-        });
+        this.setState({ 
+            queryTabs: newArray,
+            currentTab: newCurrentTab,
+            currentTabMongoId: newArray[newCurrentTab-1].mongoId
+        })
+        this.props.currentUser["queryBuilderState"] = this.state;
     }
 
     updateQueryNameHandler = (queryId, newQueryName, queryMongoId) => {
@@ -121,16 +104,16 @@ class QueryPage extends React.Component {
         this.loadQueries(queryObjects);
     }
 
-    loadQueries = async (queryObjects) => {
+    loadQueries = (queryObjects) => {
         for (let i=0; i<queryObjects.length; i++) {
             let queryObj = queryObjects[i]['query']
             queryObj.groupBy = queryObj.groupBy === undefined ||  queryObj.groupBy === null || queryObj.groupBy === "" ? {value: "", label: "None"} : queryObj.groupBy;
             queryObj.sortBy = queryObj.sortBy === null || queryObj.sortBy === undefined || queryObj.sortBy === "" ? {property: "", sortOrder: "desc"} : queryObj.sortBy;
-            await this.updateQueryObjForTab(queryObj.queryObj, queryObj.groupBy, queryObj.sortBy, this.state.currentTab, queryObj.name, queryObj._id);
+            this.updateQueryObjForTab(queryObj.queryObj, queryObj.groupBy, queryObj.sortBy, this.state.currentTab, queryObj.name, queryObj._id);
             if(this.queryResultsTableRef.current !== null) {
                 this.queryResultsTableRef.current.updateTableGroupAndSortBy(queryObj.groupBy, queryObj.sortBy);
             }
-            await this.changeQueryTab(this.state.currentTab + (i+1 < queryObjects.length ? 1 : 0))
+            this.changeQueryTab(this.state.currentTab + (i+1 < queryObjects.length ? 1 : 0))
         }
     }
 
@@ -145,7 +128,7 @@ class QueryPage extends React.Component {
         this.updateQueryState(newArray);
     }
 
-    updateQueryObjForTab = async (queryObj, groupBy, sortBy, queryId, tabName, mongoQueryId) => {
+    updateQueryObjForTab = (queryObj, groupBy, sortBy, queryId, tabName, mongoQueryId) => {
         let newArray = this.state.queryTabs.concat();
         for(let i=0; i < newArray.length; i++) {
             if(newArray[i].id === queryId) {
@@ -158,7 +141,7 @@ class QueryPage extends React.Component {
                 }
             }
         }
-        await this.updateQueryState(newArray);
+        this.updateQueryState(newArray);
     }
     
     setTableSortBy = (sortObject) => {
@@ -183,16 +166,12 @@ class QueryPage extends React.Component {
         $('#tabObj_button_' + this.state.currentObjectNum ).toggleClass( "active" );
         $('#tabObj_button_' + objectKey ).toggleClass( "active" );
 
-        return new Promise(resolve => {
-            this.setState({ 
-                    currentTab: objectKey,
-                    currentTabMongoId: this.state.queryTabs[objectKey-1].mongoId
-                }, () => {
-                    this.props.currentUser["queryBuilderState"] = this.state;
-                    resolve()
-                }
-            )
-        });
+
+        this.setState({ 
+            currentTab: objectKey,
+            currentTabMongoId: this.state.queryTabs[objectKey-1].mongoId
+        })
+        this.props.currentUser["queryBuilderState"] = this.state;
     }
 
     closeQueryTab = (queryId) => {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -839,12 +839,16 @@ ol, ul {
 .load-query-search-load-line span {
     display: flex;
     flex-direction: row;
-    margin-right: 30px;
+    padding-right: 30px;
 }
 
-.load-query-search-load-line p {
+.load-query-search-load-line a {
     margin: 7.5px 15px;
     color: grey;
+}
+
+.load-query-search-load-line a:hover {
+    text-decoration: none;
 }
 
 .load-query-search-load-line button {
@@ -922,11 +926,6 @@ ol, ul {
 .load-query-header {
     font-size: 25px;
     padding: 20px 45px;
-}
-
-.load-query-modal {
-    min-width: 97vw;
-    min-height: 97vh;
 }
 
 .icon-margin-right {
@@ -1025,12 +1024,28 @@ ol, ul {
     background-color: #1d99f052;
 }
 
+.load-query-table tbody tr.selected-row:hover {
+    background-color: #0066ff77 !important;
+}
+
+.load-query-table tbody tr:nth-child(even).selected-row:hover {
+    background-color: #0066ff83 !important;
+}
+
+.load-query-table tbody tr:hover{
+    background-color: #aad2ee52 !important;
+}
+
+.load-query-table tbody tr:nth-child(even):hover {
+    background-color: #aad2ee75 !important;
+}
+
 .load-query-table tbody tr:nth-child(even) {
     background-color: #f3f3f3cb;
 }
 
 .load-query-table tbody tr:nth-child(even).selected-row {
-    background-color: #1d99f073;
+    background-color: #229cf373;
 }
 
 .load-query-modal-title {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1056,7 +1056,7 @@ ol, ul {
     transform: scale(1.6);
 }
 
-.load-query-table .header-checkbox {
+.load-query-table .header-checkbox, .load-query-table .user {
     column-width: 1vw;
 }
 
@@ -1065,10 +1065,6 @@ ol, ul {
 }
 
 .load-query-table .date {
-    column-width: 10vw;
-}
-
-.load-query-table .user {
     column-width: 10vw;
 }
 

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1052,19 +1052,28 @@ ol, ul {
     background-color: #229cf373;
 }
 
-.load-query-modal-title {
-    flex-shrink: 0;
-    padding-left: 50px;
-    padding-top: 40px;
-}
-
-.load-query-modal .modal-header {
-    border-bottom: 0px;
-    margin-bottom: -20px;
-}
-
 .load-query-checkbox {
     transform: scale(1.6);
+}
+
+.load-query-table .header-checkbox {
+    column-width: 1vw;
+}
+
+.load-query-table .name {
+    column-width: 50vw;
+}
+
+.load-query-table .date {
+    column-width: 10vw;
+}
+
+.load-query-table .user {
+    column-width: 10vw;
+}
+
+.load-query-table .comment {
+    column-width: 28vw;
 }
 
 .load-query-search-container {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -839,6 +839,7 @@ ol, ul {
 .load-query-search-load-line span {
     display: flex;
     flex-direction: row;
+    margin-right: 30px;
 }
 
 .load-query-search-load-line p {
@@ -979,7 +980,9 @@ ol, ul {
     margin: 1px 40px;
     font-size: 0.9em;
     min-width: 400px;
-    overflow: hidden;
+    overflow-y: scroll;
+    height: 75vh;
+    display: block;
 }
 
 .load-query-table thead tr {
@@ -994,17 +997,40 @@ ol, ul {
     padding: 12px 15px;
     text-align: left;
     border: 0px solid;
-    border-bottom: 1px solid rgb(174, 174, 174)
+}
+
+.load-query-table th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: white;
+}
+
+.load-query-table th::after {
+    content: '';
+    width: 100%;
+    height: 0.1px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    background: rgb(174, 174, 174);
 }
 
 .load-query-table td {
     padding: 12px 15px;
-    border-right: 0.1px solid lightgray;
-    border-left: 0.1px solid lightgray;
+    border-bottom: 1px solid rgb(174, 174, 174)
 }
 
 .load-query-table tbody tr.selected-row {
-    background-color: #efefef;
+    background-color: #1d99f052;
+}
+
+.load-query-table tbody tr:nth-child(even) {
+    background-color: #f3f3f3cb;
+}
+
+.load-query-table tbody tr:nth-child(even).selected-row {
+    background-color: #1d99f073;
 }
 
 .load-query-modal-title {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -874,7 +874,7 @@ ol, ul {
     border-bottom: 0px;
     border-top: 2px solid #dee2e6;
     border-right: 2px solid #dee2e6;
-    border-left: 2px solid#dee2e6;
+    border-left: 2px solid #dee2e6;
     margin-bottom: -1px;
 }
 

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -992,6 +992,10 @@ ol, ul {
     text-underline-offset: 2px;
 }
 
+.load-query-table tr {
+    cursor: default;
+}
+
 .load-query-table th, .load-query-table td {
     padding: 12px 15px;
     text-align: left;

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -783,8 +783,20 @@ ol, ul {
     font-family: 'Lato' !important;
 }
 
-.query-builder-nav, .load-query-nav {
+.query-builder-nav {
     display: flex;
+}
+
+
+.load-query-nav {
+    display: flex;
+    margin-left: 40px;
+    margin-bottom: 20px;
+}
+
+.load-query-nav span {
+    display: flex;
+    flex-direction: row;
 }
 
 .query-builder-nav .nav-tabs {
@@ -803,12 +815,79 @@ ol, ul {
     padding-right: 20px;
 }
 
+.query- .nav-tabs {
+    display: flex;
+    flex-direction: row;
+    padding-left: 20px;
+    width: 100%;
+    padding-right: 20px;
+}
+
+.load-query-search-load-line {
+    display: flex;
+    flex-direction: row;
+    padding-left: 20px;
+    width: 100%;
+    padding-right: 20px;
+    justify-content: space-between;
+}
+
+.load-query-search-load-line span {
+    display: flex;
+    flex-direction: row;
+}
+
+.load-query-search-load-line p {
+    margin: 5px 15px;
+    color: grey;
+}
+
+.load-query-search-load-line button {
+    width: 163.3px;
+    height: 39px;
+    border-radius: 5px;
+    border: solid 1px #0a7bc6;
+    background-color: #58abff;
+    color: white;
+}
+
+.query-tab-controls button {
+    background: #e6f2f9;
+    border-bottom: 0px;
+    border-top: 2px solid #dee2e6;
+    border-right: 2px solid #dee2e6;
+    border-left: 2px solid#dee2e6;
+    border-radius: 5px 5px 0px 0px;
+}
+
+.query-tab-controls button.selected {
+    background: white;
+}
+
+.query-tab-controls-span {
+    display: flex;
+    flex-direction: row;
+    padding-right: 30px;
+}
+
 .query-builder-nav .nav-item, .load-query-nav .nav-item {
     margin-right: 8px;
 }
 
 .query-builder-nav .nav-item button, .load-query-nav .nav-item button {
     padding: 5px 30px;
+}
+
+.load-query-nav span button {
+    padding: 5px 10px;
+    background-color: transparent;
+    border-color: transparent;
+}
+
+.load-query-nav span button.selected {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    color: blue;
 }
 
 .query-tab-contents {
@@ -825,11 +904,18 @@ ol, ul {
     padding-right: 5px;
     padding-top: 7px;
     border-bottom: 1px solid;
-    border-bottom-style: inset
+    border-bottom-style: inset;
+    color:grey;
+}
+
+.load-query-header {
+    font-size: 25px;
+    padding: 20px 45px;
 }
 
 .load-query-modal {
-    min-width: min-content;
+    min-width: 97vw;
+    min-height: 97vh;
 }
 
 .icon-margin-right {
@@ -878,9 +964,52 @@ ol, ul {
     width: 95%;
 }
 
-.saved-query-table th {
-    text-align: center;
-    border: 1px solid #000;
+.load-query-table {
+    border-collapse: collapse;
+    margin: 1px 40px;
+    font-size: 0.9em;
+    min-width: 400px;
+    overflow: hidden;
+}
+
+.load-query-table thead tr {
+    text-align: left;
+    font-weight: bold;
+    text-decoration: 1.5px underline;
+    border-bottom: 0.5px solid #dddddd;
+    text-underline-offset: 2px;
+}
+
+.load-query-table th, .load-query-table td {
+    padding: 12px 15px;
+    text-align: left;
+    border: 0px solid;
+    border-bottom: 1px solid rgb(174, 174, 174)
+}
+
+.load-query-table td {
+    padding: 12px 15px;
+    border-right: 0.1px solid lightgray;
+    border-left: 0.1px solid lightgray;
+}
+
+.load-query-table tbody tr.selected-row {
+    background-color: #efefef;
+}
+
+.load-query-modal-title {
+    flex-shrink: 0;
+    padding-left: 50px;
+    padding-top: 40px;
+}
+
+.load-query-modal .modal-header {
+    border-bottom: 0px;
+    margin-bottom: -20px;
+}
+
+.load-query-checkbox {
+    transform: scale(1.6);
 }
 
 .load-query-search-container {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -842,7 +842,7 @@ ol, ul {
 }
 
 .load-query-search-load-line p {
-    margin: 5px 15px;
+    margin: 7.5px 15px;
     color: grey;
 }
 
@@ -870,7 +870,7 @@ ol, ul {
     border-top: 2px solid #dee2e6;
     border-right: 2px solid #dee2e6;
     border-left: 2px solid#dee2e6;
-    margin-bottom: -2px;
+    margin-bottom: -1px;
 }
 
 .query-tab-controls-span {
@@ -885,6 +885,7 @@ ol, ul {
 
 .query-builder-nav .nav-item button, .load-query-nav .nav-item button {
     padding: 5px 30px;
+    border-color: #dee2e6 #dee2e6;
 }
 
 .load-query-nav span button {
@@ -896,7 +897,7 @@ ol, ul {
 .load-query-nav span button.selected {
     text-decoration: underline;
     text-underline-offset: 4px;
-    color: blue;
+    color: #1db4f0;
 }
 
 .query-tab-contents {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -787,6 +787,10 @@ ol, ul {
     display: flex;
 }
 
+.nav-tabs .nav-item .nav-link.load-query-active {
+    border-color: #dee2e6 #dee2e6;
+    background-color: #fff;
+}
 
 .load-query-nav {
     display: flex;
@@ -854,14 +858,19 @@ ol, ul {
 .query-tab-controls button {
     background: #e6f2f9;
     border-bottom: 0px;
-    border-top: 2px solid #dee2e6;
-    border-right: 2px solid #dee2e6;
-    border-left: 2px solid#dee2e6;
+    border-top: 0px;
+    border-right: 0px;
+    border-left: 0px;
     border-radius: 5px 5px 0px 0px;
 }
 
 .query-tab-controls button.selected {
     background: white;
+    border-bottom: 0px;
+    border-top: 2px solid #dee2e6;
+    border-right: 2px solid #dee2e6;
+    border-left: 2px solid#dee2e6;
+    margin-bottom: -2px;
 }
 
 .query-tab-controls-span {

--- a/analysis-ui/src/services/config.js
+++ b/analysis-ui/src/services/config.js
@@ -1,0 +1,5 @@
+const API_URL = 'https://localhost:9100/api';
+const GRAPHQL_URL = 'http://localhost:9100/graphql';
+const RESOURCES_URL = 'https://resources.machinecommonsense.com';
+
+module.exports = {API_URL, GRAPHQL_URL, RESOURCES_URL};

--- a/analysis-ui/src/services/config.js
+++ b/analysis-ui/src/services/config.js
@@ -1,5 +1,0 @@
-const API_URL = 'https://localhost:9100/api';
-const GRAPHQL_URL = 'http://localhost:9100/graphql';
-const RESOURCES_URL = 'https://resources.machinecommonsense.com';
-
-module.exports = {API_URL, GRAPHQL_URL, RESOURCES_URL};


### PR DESCRIPTION
First time touching React since August so I was a little rusty but I think this turned out good. I added a bonus of rows being highlighted when you hover over them so you know that you are going to select it and that you can click the entire row, not just the checkbox to make a selection. David wanted alternating rows to be  slightly different colors so that's the case for both unselected (white/light-grey) and selected rows (light-blue/dark-blue).

Selecting one query will replace the current query tab. Selecting more than one query will append multiple queries to the end of the tab list.

Here is a screenshot of the original design idea from zeplin that I tried to match.
![Screen Shot 2022-05-24 at 4 54 31 PM (1)](https://user-images.githubusercontent.com/52011587/172497103-ee544a8a-29cc-48da-869e-5e2a3d77c634.png)

