### PR TITLE
Cube results table scrolls with videos

### DIFF
--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -170,22 +170,14 @@ class Scenes extends React.Component {
                     search: searchString + sceneToUpdate
                 });
             }
-            
-            if (downOneOrUpOneScene) {
-                let sceneRow = document.getElementById("score_table_row_scene_" + sceneNum);
-                if (sceneRow !== null) {
-                    let currentScrollPosition = document.documentElement.scrollTop;
-                    let rowPosition = sceneRow.style.position;
-                    let top = sceneRow.style.top;
-                    sceneRow.style.position = 'relative';
-                    sceneRow.style.top = '-30px';
-                    sceneRow.scrollIntoView({block: 'start'});
-                    sceneRow.style.top = top;
-                    sceneRow.style.position = rowPosition;
-                    document.documentElement.scrollTop = currentScrollPosition;
-                }
+            let sceneRow = document.getElementById("score_table_row_scene_" + sceneNum);
+            if (sceneRow !== null && downOneOrUpOneScene) {
+                let currentScrollPosition = document.documentElement.scrollTop;
+                sceneRow.classList.toggle('analysis-table-selected-row');
+                sceneRow.scrollIntoView({block: 'start'});
+                sceneRow.classList.toggle('analysis-table-selected-row');
+                document.documentElement.scrollTop = currentScrollPosition;
             }
-            
             this.props.updateHandler("scene", sceneNum);
             this.resetVideoState(matchSpeed);
         }

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -171,25 +171,23 @@ class Scenes extends React.Component {
                 });
             }
             
-            
             if (downOneOrUpOneScene) {
                 let sceneRow = document.getElementById("score_table_row_scene_" + sceneNum);
                 if (sceneRow !== null) {
                     let currentScrollPosition = document.documentElement.scrollTop;
-                    let pos = sceneRow.style.position;
+                    let rowPosition = sceneRow.style.position;
                     let top = sceneRow.style.top;
                     sceneRow.style.position = 'relative';
                     sceneRow.style.top = '-30px';
                     sceneRow.scrollIntoView({block: 'start'});
                     sceneRow.style.top = top;
-                    sceneRow.style.position = pos;
+                    sceneRow.style.position = rowPosition;
                     document.documentElement.scrollTop = currentScrollPosition;
                 }
             }
             
             this.props.updateHandler("scene", sceneNum);
             this.resetVideoState(matchSpeed);
-            
         }
     }
 

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -170,9 +170,17 @@ class Scenes extends React.Component {
                     search: searchString + sceneToUpdate
                 });
             }
+            
+            let currentScrollPosition = document.documentElement.scrollTop;
+            let sceneRow = document.getElementById("score_table_row_scene_" + sceneNum);
+            if (sceneRow !== null) {
+                sceneRow.scrollIntoView({block: 'nearest'});
+                document.documentElement.scrollTop = currentScrollPosition;
+            }
+            
             this.props.updateHandler("scene", sceneNum);
-
             this.resetVideoState(matchSpeed);
+            
         }
     }
 

--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -149,7 +149,7 @@ class Scenes extends React.Component {
         this.setState({[key]: value});
     }
 
-    changeScene = (sceneNum, matchSpeed=false) => {
+    changeScene = (sceneNum, matchSpeed=false, downOneOrUpOneScene=false) => {
         if(this.state.currentSceneNum !== sceneNum) {
             this.setState({ currentSceneNum: sceneNum});
             let pathname = this.props.value.history.location.pathname;
@@ -171,11 +171,20 @@ class Scenes extends React.Component {
                 });
             }
             
-            let currentScrollPosition = document.documentElement.scrollTop;
-            let sceneRow = document.getElementById("score_table_row_scene_" + sceneNum);
-            if (sceneRow !== null) {
-                sceneRow.scrollIntoView({block: 'nearest'});
-                document.documentElement.scrollTop = currentScrollPosition;
+            
+            if (downOneOrUpOneScene) {
+                let sceneRow = document.getElementById("score_table_row_scene_" + sceneNum);
+                if (sceneRow !== null) {
+                    let currentScrollPosition = document.documentElement.scrollTop;
+                    let pos = sceneRow.style.position;
+                    let top = sceneRow.style.top;
+                    sceneRow.style.position = 'relative';
+                    sceneRow.style.top = '-30px';
+                    sceneRow.scrollIntoView({block: 'start'});
+                    sceneRow.style.top = top;
+                    sceneRow.style.position = pos;
+                    document.documentElement.scrollTop = currentScrollPosition;
+                }
             }
             
             this.props.updateHandler("scene", sceneNum);
@@ -215,13 +224,13 @@ class Scenes extends React.Component {
 
     upOneScene = () => {
         if(this.state.currentSceneNum-1 > 0)
-            this.changeScene(this.state.currentSceneNum-1);
+            this.changeScene(this.state.currentSceneNum-1, false, true);
     }
 
     downOneScene = (numOfScenes, checkState) => {
         if((checkState && this.state.playAll) || !checkState) {
             if (this.state.currentSceneNum < numOfScenes) {
-                this.changeScene(this.state.currentSceneNum+1, true);
+                this.changeScene(this.state.currentSceneNum+1, true, true);
             }
         }
     }

--- a/analysis-ui/src/components/Analysis/scoreTable.jsx
+++ b/analysis-ui/src/components/Analysis/scoreTable.jsx
@@ -43,7 +43,7 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
 
     return (
         <div className="score-table-div">
-            <Table className="score-table" aria-label="simple table">
+            <Table className="score-table" aria-label="simple table" stickyHeader>
                 <TableHead>
                     <TableRow>
                     {columns.map((col, colKey) => (
@@ -71,7 +71,7 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
                 </TableHead>
                 <TableBody>
                 {currentPerformerScenes !== undefined && _.values(currentPerformerScenes).sort(getSorting(sortOption.sortOrder, sortOption.sortBy)).map((scoreObj, rowKey) => 
-                    <TableRow classes={{ root: 'TableRow'}} className="pointer-on-hover" key={'performer_score_row_' + rowKey} hover selected={currentSceneNum === scoreObj.scene_num} onClick={()=> changeSceneHandler(scoreObj.scene_num)}> 
+                    <TableRow classes={{ root: 'TableRow'}} id={'score_table_row_scene_' + (parseInt(rowKey) + 1)} className="pointer-on-hover" key={'performer_score_row_' + rowKey} hover selected={currentSceneNum === scoreObj.scene_num} onClick={()=> changeSceneHandler(scoreObj.scene_num)}> 
                         {columns.map((col, colKey) => (
                             <TableCell key={"performer_score_row_" + rowKey + "_col_" + colKey}>
                                 {col.title === 'Evaluation Score' &&

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -950,6 +950,12 @@ ol, ul {
     margin: 30px;
 }
 
+.results-table-scroll {
+    width: 98%;
+    overflow-x: scroll;
+    padding: 0 8px 8px 0;
+    max-height: 700px;
+}
 
 .results-table-scroll thead tr th {
     position: sticky;

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1274,3 +1274,8 @@ nav.MuiList-root.nav-list.MuiList-padding {
 .playback-btns-passive {
     padding-left: 345px;
 }
+
+.analysis-table-selected-row {
+    position: relative;
+    top: -30px;
+}

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -276,7 +276,7 @@ ol, ul {
     width: 98%;
     overflow: scroll;
     padding: 0 8px 8px 0;
-    max-height: 500px;
+    max-height: 295px;
 }
 
 .score-table-div .table, .object-contents .table {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -272,6 +272,13 @@ ol, ul {
     margin: 5px 10px 10px 10px;
 }
 
+.score-table-div {
+    width: 98%;
+    overflow: scroll;
+    padding: 0 8px 8px 0;
+    max-height: 500px;
+}
+
 .score-table-div .table, .object-contents .table {
     border: 1px solid black;
     padding: 5px 15px 5px 15px; 
@@ -943,12 +950,6 @@ ol, ul {
     margin: 30px;
 }
 
-.results-table-scroll {
-    width: 98%;
-    overflow-x: scroll;
-    padding: 0 8px 8px 0;
-    max-height: 700px;
-}
 
 .results-table-scroll thead tr th {
     position: sticky;


### PR DESCRIPTION
The table now scrolls with a fixed header. The position of the highlighted current scene will always be in view of the table window. This is helpful especially for the play all feature as the table scrolls with the videos as you play through each scene moving down the table.