### PR TITLE
Fix scene query on analysis view.

### DIFF
--- a/analysis-ui/src/components/Analysis/scenes.jsx
+++ b/analysis-ui/src/components/Analysis/scenes.jsx
@@ -299,7 +299,9 @@ class Scenes extends React.Component {
     }
 
     getSceneNamePrefix = (name) => {
-        return name.substring(0, name.indexOf('_')) + '*';
+        let secondToLastIndex = name.lastIndexOf('_', name.lastIndexOf('_')-1)
+
+        return name.substring(0, secondToLastIndex) + '*';
     }
 
     checkIfScenesExist = (scenesByPerformer) =>{

--- a/analysis-ui/src/components/Analysis/scoreTable.jsx
+++ b/analysis-ui/src/components/Analysis/scoreTable.jsx
@@ -38,7 +38,7 @@ function ScoreTable({columns, currentPerformerScenes, currentSceneNum,
     };
 
     const getCurrentScene = (scenesInOrder) => {
-        return scenesInOrder[currentSceneNum - 1];
+        return scenesInOrder.find(scene => scene.scene_num === currentSceneNum);
     }
 
     return (


### PR DESCRIPTION
We're using the prefix of the name of scenes to query on the scene analysis view. It was only using everything up to the first underscore, which is obviously a problem for something like "eval_5_validation_scene_whatever_0001_01". Should now be using everything up to the second to last underscore. 

Also noticed we were relying on all scenes being present, but we have partial hypercubes for validation data. 