### PR TITLE
MCS-1396:  Make chart height larger

### DIFF
--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -719,7 +719,7 @@ ol, ul {
 }
 
 .results-chart-container {
-    height: 450px;
+    height: 900px;
     width: 900px;
     padding-top: 30px;
 }


### PR DESCRIPTION
Due to the number of different test types in Evaluation 5, we should make the charts larger so that we can eliminate some bunching that was occurring.