### PR TITLE
MCS-1349 scorecard updates

### DIFF
--- a/analysis-ui/src/components/Analysis/scorecard.jsx
+++ b/analysis-ui/src/components/Analysis/scorecard.jsx
@@ -14,6 +14,18 @@ function ScoreCardModal({show, onHide, scorecardObject, currentSceneNum}) {
             .join(' '));
     }
 
+    const isValueNonNullObject = (scorecardObject, key) => {
+        return scorecardObject[key] !== null && typeof scorecardObject[key] == 'object';
+    }
+
+    const printValue = (scorecardObject) => {
+        if(scorecardObject === null) {
+            return "N/A";
+        } else {
+            return scorecardObject;
+        }
+    }
+
     return (
         <Modal show={show} onHide={closeModal} size="lg" aria-labelledby="contained-modal-title-vcenter" centered scrollable={true}>
             <Modal.Header closeButton>
@@ -28,7 +40,33 @@ function ScoreCardModal({show, onHide, scorecardObject, currentSceneNum}) {
             <Modal.Body>
                 <div className="scene-table-div">
                     {scorecardObject !== undefined && Object.keys(scorecardObject).map((objectKey, key) => 
-                        <div key={"scorecard_row_" + key}>{cleanupKeyString(objectKey) + ": " + scorecardObject[objectKey]}</div>
+                        <>
+                            {isValueNonNullObject(scorecardObject, objectKey) &&
+                                <>
+                                    {Object.keys(scorecardObject[objectKey]).length > 0 &&
+                                        <>
+                                            <div key={"scorecard_row_" + key}>{cleanupKeyString(objectKey) + ": "}</div>
+                                            <ul>
+                                                {scorecardObject[objectKey] !== undefined && scorecardObject[objectKey] !== null && Object.keys(scorecardObject[objectKey]).map((subObjKey, subKey) => 
+                                                    <li key={"scorecard_sub_row_" + subKey}>{cleanupKeyString(subObjKey) + ": " + printValue(scorecardObject[objectKey][subObjKey])}</li>
+                                                )}
+                                            </ul>
+                                        </>
+                                    }
+
+                                    {Object.keys(scorecardObject[objectKey]).length === 0 &&
+                                        <div className="single-scorecard-item" key={"scorecard_row_" + key}>{cleanupKeyString(objectKey) + ": N/A"}</div>
+                                    }
+                                </>
+                            }
+                            {(!isValueNonNullObject(scorecardObject, objectKey)) &&
+                                <>
+                                    <div className="single-scorecard-item" key={"scorecard_row_" + key}>
+                                        {cleanupKeyString(objectKey) + ": " + printValue(scorecardObject[objectKey])}
+                                    </div>
+                                </>
+                            }
+                        </>
                     )}
                 </div>
             </Modal.Body>

--- a/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
+++ b/analysis-ui/src/components/TestOverview/hypercubeResultsTable.jsx
@@ -124,7 +124,7 @@ class HyperCubeResultsTable extends React.Component {
                             </Table>
 
                             {/* Exclude Evaluation 3 Results because we didn't have scorecard functionality yet */}
-                            {((testType === "interactive" || testType === 'retrieval') && this.props.state.eval !== "Evaluation 3 Results")  &&
+                            {((testType === "interactive" || testType === 'retrieval') && this.props.state.eval !== "eval_3_results")  &&
                                 <ScoreCardTable state={this.props.state} downloadCSV={this.downloadCSV}/>
                             }
                         </>

--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -40,8 +40,8 @@ const scorecardFieldsLatest = [
     {"title": "Correct Platform", "key": "totalCorrectPlatform"},
     {"title": "Correct Door Opened", "key": "totalCorrectDoorOpened"},
     {"title": "Fastest Path", "key": "totalFastestPath"},
-    {"title": "Move Tool Success", "key": "totalMoveToolSuccess"},
-    {"title": "Move Tool Failure", "key": "totalMoveToolFailure"},
+    {"title": "Move Tool Success (Push, Rotate, etc)", "key": "totalMoveToolSuccess"},
+    {"title": "Move Tool Failure (Push, Rotate, etc)", "key": "totalMoveToolFailure"},
     {"title": "Pickup Not Pickupable", "key": "totalPickupNotPickupable"},
     {"title": "Interact With Non Agent", "key": "totalInteractWithNonAgent"}
 ];

--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -14,6 +14,8 @@ const getScorecardDataQuery = gql`
         getScoreCardData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata) 
     }`;
 
+
+/*
 const scorecardFields = [
     {"title": "HyperCubeId", "key": "hypercubeID"},
     {"title": "Repeat Failed", "key": "totalRepeatFailed"},
@@ -22,6 +24,35 @@ const scorecardFields = [
     {"title": "Multiple Container Look", "key": "totalMultipleContainerLook"},
     {"title": "Not Moving Toward Object", "key": "totalNotMovingTowardObject"},
     {"title": "Revisits", "key": "totalRevisits"}
+];*/
+const scorecardFields = [
+    {"title": "HyperCubeId", "key": "hypercubeID"},
+    {"title": "Repeat Failed", "key": "totalRepeatFailed"},
+    {"title": "Attempt Impossible", "key": "totalAttemptImpossible"},
+    {"title": "Open Unopenable", "key": "totalOpenUnopenable"},
+    {"title": "Multiple Container Look", "key": "totalContainerRelook"},
+    {"title": "Not Moving Toward Object", "key": "totalNotMovingTowardObject"},
+    {"title": "Revisits", "key": "totalRevisits"},
+    {"title": "Ramp Went Up", "key": "totalRampWentUp"},
+    {"title": "Ramp Went Down", "key": "totalRampWentDown"},
+    {"title": "Ramp Went Up Abandoned", "key": "totalRampWentUpAbandoned"},
+    {"title": "Ramp Went Down Abandoned", "key": "totalRampWentDownAbandoned"},
+    {"title": "Ramp Fell Off", "key": "totalRampFellOff"},
+    {"title": "Correct Platform", "key": "totalCorrectPlatform"},
+    {"title": "Correct Door Opened", "key": "totalCorrectDoorOpened"},
+    {"title": "Fastest Path", "key": "totalFastestPath"},
+    {"title": "Move Tool Success", "key": "totalMoveToolSuccess"},
+    {"title": "Move Tool Failure", "key": "totalMoveToolFailed"},
+    {"title": "Push Tool Success", "key": "totalPushToolSuccess"},
+    {"title": "Push Tool Failure", "key": "totalPushToolFailed"},
+    {"title": "Pull Tool Success", "key": "totalPullToolSuccess"},
+    {"title": "Pull Tool Failure", "key": "totalPullToolFailed"},
+    {"title": "Rotate Tool Success", "key": "totalRotateToolSuccess"},
+    {"title": "Rotate Tool Failure", "key": "totalRotateToolFailed"},
+    {"title": "Torque Tool Success", "key": "totalTorqueToolSuccess"},
+    {"title": "Torque Tool Failure", "key": "totalTorqueToolFailed"},
+    {"title": "Pickup Not Pickupable", "key": "totalPickupNotPickupable"},
+    {"title": "Interact With Non Agent", "key": "totalInteractWithNonAgent"}
 ];
 class ScoreCardTable extends React.Component {
 

--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -40,8 +40,8 @@ const scorecardFieldsLatest = [
     {"title": "Correct Platform", "key": "totalCorrectPlatform"},
     {"title": "Correct Door Opened", "key": "totalCorrectDoorOpened"},
     {"title": "Fastest Path", "key": "totalFastestPath"},
-    {"title": "Move Tool Success (Push, Rotate, etc)", "key": "totalMoveToolSuccess"},
-    {"title": "Move Tool Failure (Push, Rotate, etc)", "key": "totalMoveToolFailure"},
+    {"title": "Move Tool Success (Push/Rotate/etc)", "key": "totalMoveToolSuccess"},
+    {"title": "Move Tool Failure (Push/Rotate/etc)", "key": "totalMoveToolFailure"},
     {"title": "Pickup Not Pickupable", "key": "totalPickupNotPickupable"},
     {"title": "Interact With Non Agent", "key": "totalInteractWithNonAgent"}
 ];

--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -14,7 +14,7 @@ const getScorecardDataQuery = gql`
         getScoreCardData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata) 
     }`;
 
-const scorecardFieldsPreEval5 = [
+const scorecardFieldsEval4 = [
     {"title": "HyperCubeId", "key": "hypercubeID"},
     {"title": "Repeat Failed", "key": "totalRepeatFailed"},
     {"title": "Attempt Impossible", "key": "totalAttemptImpossible"},
@@ -74,10 +74,6 @@ class ScoreCardTable extends React.Component {
         this.props.downloadCSV(scorecardData, scorecardFields, titleString)
     }
 
-    isPreEval5(evalResults) {
-        return evalResults === "eval_4_results" || evalResults === "eval_3_results";
-    }
-
     render() {
         return (
             <Query query={getScorecardDataQuery} variables={{
@@ -90,7 +86,8 @@ class ScoreCardTable extends React.Component {
                     if (loading) return <div>Loading ...</div> 
                     if (error) return <div>Error</div>
 
-                    const scorecardFields = this.isPreEval5(this.props.state.eval) ? scorecardFieldsPreEval5 : scorecardFieldsLatest;
+                    const isEval4 = this.props.state.eval === "eval_4_results";
+                    const scorecardFields = isEval4 ? scorecardFieldsEval4 : scorecardFieldsLatest;
                     const scorecardData = data[scorecardDataQueryName];
                     const tableTitle = "Scorecard (" + this.props.state.category + "/" + 
                         this.props.state.performer + "/" + this.props.state.metadata + ")";
@@ -109,33 +106,35 @@ class ScoreCardTable extends React.Component {
                                         </IconButton>
                                     </div>
                                 </div>
-                                <Table className="score-table" aria-label="simple table" stickyHeader>
-                                    <TableHead>
-                                        <TableRow>
-                                            {scorecardFields.map((field, key) =>
-                                                <TableCell key={'scorecard_header_cell' + key}>{field.title}</TableCell>
+                                <div className="scorecard-table-container">
+                                    <Table className="score-table" aria-label="simple table">
+                                        <TableHead>
+                                            <TableRow>
+                                                {scorecardFields.map((field, key) =>
+                                                    <TableCell key={'scorecard_header_cell' + key}>{field.title}</TableCell>
+                                                )}
+                                            </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                            {scorecardData.map((scoreCardCell, hyperKey) =>
+                                                <TableRow key={'scorecard_row_' + hyperKey} classes={{ root: 'TableRow'}}>
+                                                    {scorecardFields.map((field, fieldKey) => 
+                                                        <TableCell key={'scorecard_row_cell_' + hyperKey + fieldKey}>
+                                                            {field["key"] === "hypercubeID" ? scoreCardCell["_id"][field["key"]] : scoreCardCell[field["key"]]}
+                                                        </TableCell>
+                                                    )}
+                                                </TableRow>
                                             )}
-                                        </TableRow>
-                                    </TableHead>
-                                    <TableBody>
-                                        {scorecardData.map((scoreCardCell, hyperKey) =>
-                                            <TableRow key={'scorecard_row_' + hyperKey} classes={{ root: 'TableRow'}}>
-                                                {scorecardFields.map((field, fieldKey) => 
-                                                    <TableCell key={'scorecard_row_cell_' + hyperKey + fieldKey}>
-                                                        {field["key"] === "hypercubeID" ? scoreCardCell["_id"][field["key"]] : scoreCardCell[field["key"]]}
+                                            <TableRow classes={{ root: 'TableRow'}}>
+                                                {scorecardFields.map((field, key) =>
+                                                    <TableCell key={'scorecard_total_cell' + key}>
+                                                        {field["key"] === "hypercubeID" ? "Totals" : this.getTotalScoreCardValue(scorecardData, field["key"])}
                                                     </TableCell>
                                                 )}
                                             </TableRow>
-                                        )}
-                                        <TableRow classes={{ root: 'TableRow'}}>
-                                            {scorecardFields.map((field, key) =>
-                                                <TableCell key={'scorecard_total_cell' + key}>
-                                                    {field["key"] === "hypercubeID" ? "Totals" : this.getTotalScoreCardValue(scorecardData, field["key"])}
-                                                </TableCell>
-                                            )}
-                                        </TableRow>
-                                    </TableBody>
-                                </Table>
+                                        </TableBody>
+                                    </Table>
+                                </div>
                             </div>
                         }
                         </>

--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -14,17 +14,6 @@ const getScorecardDataQuery = gql`
         getScoreCardData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata) 
     }`;
 
-
-/*
-const scorecardFields = [
-    {"title": "HyperCubeId", "key": "hypercubeID"},
-    {"title": "Repeat Failed", "key": "totalRepeatFailed"},
-    {"title": "Attempt Impossible", "key": "totalAttemptImpossible"},
-    {"title": "Open Unopenable", "key": "totalOpenUnopenable"},
-    {"title": "Multiple Container Look", "key": "totalMultipleContainerLook"},
-    {"title": "Not Moving Toward Object", "key": "totalNotMovingTowardObject"},
-    {"title": "Revisits", "key": "totalRevisits"}
-];*/
 const scorecardFields = [
     {"title": "HyperCubeId", "key": "hypercubeID"},
     {"title": "Repeat Failed", "key": "totalRepeatFailed"},

--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -14,7 +14,17 @@ const getScorecardDataQuery = gql`
         getScoreCardData(eval: $eval, categoryType: $categoryType, performer: $performer, metadata: $metadata) 
     }`;
 
-const scorecardFields = [
+const scorecardFieldsPreEval5 = [
+    {"title": "HyperCubeId", "key": "hypercubeID"},
+    {"title": "Repeat Failed", "key": "totalRepeatFailed"},
+    {"title": "Attempt Impossible", "key": "totalAttemptImpossible"},
+    {"title": "Open Unopenable", "key": "totalOpenUnopenable"},
+    {"title": "Multiple Container Look", "key": "totalContainerRelook"},
+    {"title": "Not Moving Toward Object", "key": "totalNotMovingTowardObject"},
+    {"title": "Revisits", "key": "totalRevisits"}
+];
+
+const scorecardFieldsLatest = [
     {"title": "HyperCubeId", "key": "hypercubeID"},
     {"title": "Repeat Failed", "key": "totalRepeatFailed"},
     {"title": "Attempt Impossible", "key": "totalAttemptImpossible"},
@@ -31,15 +41,7 @@ const scorecardFields = [
     {"title": "Correct Door Opened", "key": "totalCorrectDoorOpened"},
     {"title": "Fastest Path", "key": "totalFastestPath"},
     {"title": "Move Tool Success", "key": "totalMoveToolSuccess"},
-    {"title": "Move Tool Failure", "key": "totalMoveToolFailed"},
-    {"title": "Push Tool Success", "key": "totalPushToolSuccess"},
-    {"title": "Push Tool Failure", "key": "totalPushToolFailed"},
-    {"title": "Pull Tool Success", "key": "totalPullToolSuccess"},
-    {"title": "Pull Tool Failure", "key": "totalPullToolFailed"},
-    {"title": "Rotate Tool Success", "key": "totalRotateToolSuccess"},
-    {"title": "Rotate Tool Failure", "key": "totalRotateToolFailed"},
-    {"title": "Torque Tool Success", "key": "totalTorqueToolSuccess"},
-    {"title": "Torque Tool Failure", "key": "totalTorqueToolFailed"},
+    {"title": "Move Tool Failure", "key": "totalMoveToolFailure"},
     {"title": "Pickup Not Pickupable", "key": "totalPickupNotPickupable"},
     {"title": "Interact With Non Agent", "key": "totalInteractWithNonAgent"}
 ];
@@ -54,7 +56,7 @@ class ScoreCardTable extends React.Component {
         return currentTotal;
     }
 
-    prepareDataForCSV(scorecardData, titleString){
+    prepareDataForCSV(scorecardData, titleString, scorecardFields){
         for(let i=0; i < scorecardData.length; i++) {
             scorecardData[i].hypercubeID = scorecardData[i]._id.hypercubeID;
         }
@@ -72,6 +74,10 @@ class ScoreCardTable extends React.Component {
         this.props.downloadCSV(scorecardData, scorecardFields, titleString)
     }
 
+    isPreEval5(evalResults) {
+        return evalResults === "eval_4_results" || evalResults === "eval_3_results";
+    }
+
     render() {
         return (
             <Query query={getScorecardDataQuery} variables={{
@@ -84,6 +90,7 @@ class ScoreCardTable extends React.Component {
                     if (loading) return <div>Loading ...</div> 
                     if (error) return <div>Error</div>
 
+                    const scorecardFields = this.isPreEval5(this.props.state.eval) ? scorecardFieldsPreEval5 : scorecardFieldsLatest;
                     const scorecardData = data[scorecardDataQueryName];
                     const tableTitle = "Scorecard (" + this.props.state.category + "/" + 
                         this.props.state.performer + "/" + this.props.state.metadata + ")";
@@ -95,7 +102,7 @@ class ScoreCardTable extends React.Component {
                                 <h4>{tableTitle}</h4>
                                 <div className="overview-results-csv-holder">
                                     <div className="csv-results-child">
-                                        <IconButton onClick={() => {this.prepareDataForCSV(scorecardData, tableTitle)}}>
+                                        <IconButton onClick={() => {this.prepareDataForCSV(scorecardData, tableTitle, scorecardFields)}}>
                                             <span className="material-icons">
                                                 get_app
                                             </span>CSV

--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -43,7 +43,8 @@ const scorecardFieldsLatest = [
     {"title": "Move Tool Success (Push/Rotate/etc)", "key": "totalMoveToolSuccess"},
     {"title": "Move Tool Failure (Push/Rotate/etc)", "key": "totalMoveToolFailure"},
     {"title": "Pickup Not Pickupable", "key": "totalPickupNotPickupable"},
-    {"title": "Interact With Non Agent", "key": "totalInteractWithNonAgent"}
+    {"title": "Interact With Non Agent", "key": "totalInteractWithNonAgent"},
+    {"title": "Walked Into Structures", "key": "totalWalkedIntoStructures"}
 ];
 class ScoreCardTable extends React.Component {
 

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1411,6 +1411,7 @@ nav.MuiList-root.nav-list.MuiList-padding {
 }
 
 .test-overview-area {
+    max-width: 80%;
     margin: 10px 20px;
     flex: 1;
 }
@@ -1433,6 +1434,22 @@ nav.MuiList-root.nav-list.MuiList-padding {
 
 .single-scorecard-item {
     margin-bottom: 1rem;
+}
+
+.scorecard-table-container table.MuiTable-root {
+    flex-wrap: nowrap;
+    border-collapse: separate;
+}
+
+.scorecard-table-container {
+    width: 100%;
+    max-height: 700px;
+    overflow-x: auto;
+    overflow-y: auto;
+}
+
+.scorecard-table-container th.MuiTableCell-root.MuiTableCell-head {
+    min-width: 130px;
 }
 
 .overview-results-csv-holder {

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -1267,3 +1267,7 @@ nav.MuiList-root.nav-list.MuiList-padding {
 .playback-btns-passive {
     padding-left: 345px;
 }
+
+.single-scorecard-item {
+    margin-bottom: 1rem;
+}

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -554,14 +554,8 @@ const mcsResolvers = {
                 "_id": {"hypercubeID": "$scene_goal_id"},
                 "totalAttemptImpossible": { "$sum" : "$score.scorecard.attempt_impossible" },
                 "totalOpenUnopenable": { "$sum" : "$score.scorecard.open_unopenable.total_unopenable_attempts" },
-                // A couple values changed slightly...
-                // Eval 4 value
-                //"totalMultipleContainerLook": { "$sum" : "$score.scorecard.multiple_container_look" },
-                //"eval4RepeatFailed": { "$sum" : "$score.scorecard.repeat_failed" },
-                // Eval 5 value
                 "totalRepeatFailed": { "$sum" : "$score.scorecard.repeat_failed.total_repeat_failed" },
                 "totalContainerRelook": { "$sum" : "$score.scorecard.container_relook" },
-                // end
                 "totalNotMovingTowardObject": { "$sum" : "$score.scorecard.not_moving_toward_object" },
                 "totalRevisits": { "$sum" : "$score.scorecard.revisits" },
                 "totalCorrectPlatform": {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -607,7 +607,8 @@ const mcsResolvers = {
                 },
                 // end tool use stats
                 "totalPickupNotPickupable": { "$sum" : "$score.scorecard.pickup_not_pickupable" },
-                "totalInteractWithNonAgent": { "$sum" : "$score.scorecard.interact_with_non_agent" }
+                "totalInteractWithNonAgent": { "$sum" : "$score.scorecard.interact_with_non_agent" },
+                "totalWalkedIntoStructures": { "$sum" : "$score.scorecard.walked_into_structures" }
             }
 
             const scoreCardStats = await mcsDB.db.collection(args.eval).aggregate([

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -581,16 +581,28 @@ const mcsResolvers = {
                 "totalRampFellOff": { "$sum" : "$score.scorecard.ramp_actions.ramp_fell_off" },
                 // end ramp stats
                 // start tool use stats
-                "totalMoveToolSuccess": { "$sum" : "$score.scorecard.tool_usage.MoveObject" },
-                "totalMoveToolFailed": { "$sum" : "$score.scorecard.tool_usage.MoveObject_failed" },
-                "totalPushToolSuccess": { "$sum" : "$score.scorecard.tool_usage.PushObject" },
-                "totalPushToolFailed": { "$sum" : "$score.scorecard.tool_usage.PushObject_failed" },
-                "totalPullToolSuccess": { "$sum" : "$score.scorecard.tool_usage.PullObject" },
-                "totalPullToolFailed": { "$sum" : "$score.scorecard.tool_usage.PullObject_failed" },
-                "totalRotateToolSuccess": { "$sum" : "$score.scorecard.tool_usage.RotateObject" },
-                "totalRotateToolFailed": { "$sum" : "$score.scorecard.tool_usage.RotateObject_failed" },
-                "totalTorqueToolSuccess": { "$sum" : "$score.scorecard.tool_usage.TorqueObject" },
-                "totalTorqueToolFailed": { "$sum" : "$score.scorecard.tool_usage.TorqueObject_failed" },
+                "totalMoveToolSuccess": { 
+                    "$sum" : {
+                        "$add": [
+                            { "$ifNull": ["$score.scorecard.tool_usage.MoveObject", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.PushObject", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.PullObject", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.RotateObject", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.TorqueObject", 0] }
+                        ]
+                    }
+                },
+                "totalMoveToolFailure": { 
+                    "$sum" : {
+                        "$add": [
+                            { "$ifNull": ["$score.scorecard.tool_usage.MoveObject_failed", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.PushObject_failed", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.PullObject_failed", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.RotateObject_failed", 0] },
+                            { "$ifNull": ["$score.scorecard.tool_usage.TorqueObject_failed", 0] }
+                        ]
+                    }
+                },
                 // end tool use stats
                 "totalPickupNotPickupable": { "$sum" : "$score.scorecard.pickup_not_pickupable" },
                 "totalInteractWithNonAgent": { "$sum" : "$score.scorecard.interact_with_non_agent" }

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -552,12 +552,54 @@ const mcsResolvers = {
 
             const groupObject = {
                 "_id": {"hypercubeID": "$scene_goal_id"},
-                "totalRepeatFailed": { "$sum" : "$score.scorecard.repeat_failed" },
                 "totalAttemptImpossible": { "$sum" : "$score.scorecard.attempt_impossible" },
-                "totalOpenUnopenable": { "$sum" : "$score.scorecard.open_unopenable" },
-                "totalMultipleContainerLook": { "$sum" : "$score.scorecard.multiple_container_look" },
+                "totalOpenUnopenable": { "$sum" : "$score.scorecard.open_unopenable.total_unopenable_attempts" },
+                // A couple values changed slightly...
+                // Eval 4 value
+                //"totalMultipleContainerLook": { "$sum" : "$score.scorecard.multiple_container_look" },
+                //"eval4RepeatFailed": { "$sum" : "$score.scorecard.repeat_failed" },
+                // Eval 5 value
+                "totalRepeatFailed": { "$sum" : "$score.scorecard.repeat_failed.total_repeat_failed" },
+                "totalContainerRelook": { "$sum" : "$score.scorecard.container_relook" },
+                // end
                 "totalNotMovingTowardObject": { "$sum" : "$score.scorecard.not_moving_toward_object" },
                 "totalRevisits": { "$sum" : "$score.scorecard.revisits" },
+                "totalCorrectPlatform": {
+                    "$sum": {
+                        "$cond": [ "$score.scorecard.correct_platform_side", 1, 0 ]
+                    }
+                },
+                "totalCorrectDoorOpened": {
+                    "$sum": {
+                        "$cond": [ "$score.scorecard.correct_door_opened", 1, 0 ]
+                    }
+                },
+                "totalFastestPath": {
+                    "$sum": {
+                        "$cond": [ "$score.scorecard.fastest_path", 1, 0 ]
+                    }
+                },
+                // start ramp stats
+                "totalRampWentUp": { "$sum" : "$score.scorecard.ramp_actions.went_up" },
+                "totalRampWentDown": { "$sum" : "$score.scorecard.ramp_actions.went_down" },
+                "totalRampWentUpAbandoned": { "$sum" : "$score.scorecard.ramp_actions.went_up_abandoned" },
+                "totalRampWentDownAbandoned": { "$sum" : "$score.scorecard.ramp_actions.went_down_abandoned" },
+                "totalRampFellOff": { "$sum" : "$score.scorecard.ramp_actions.ramp_fell_off" },
+                // end ramp stats
+                // start tool use stats
+                "totalMoveToolSuccess": { "$sum" : "$score.scorecard.tool_usage.MoveObject" },
+                "totalMoveToolFailed": { "$sum" : "$score.scorecard.tool_usage.MoveObject_failed" },
+                "totalPushToolSuccess": { "$sum" : "$score.scorecard.tool_usage.PushObject" },
+                "totalPushToolFailed": { "$sum" : "$score.scorecard.tool_usage.PushObject_failed" },
+                "totalPullToolSuccess": { "$sum" : "$score.scorecard.tool_usage.PullObject" },
+                "totalPullToolFailed": { "$sum" : "$score.scorecard.tool_usage.PullObject_failed" },
+                "totalRotateToolSuccess": { "$sum" : "$score.scorecard.tool_usage.RotateObject" },
+                "totalRotateToolFailed": { "$sum" : "$score.scorecard.tool_usage.RotateObject_failed" },
+                "totalTorqueToolSuccess": { "$sum" : "$score.scorecard.tool_usage.TorqueObject" },
+                "totalTorqueToolFailed": { "$sum" : "$score.scorecard.tool_usage.TorqueObject_failed" },
+                // end tool use stats
+                "totalPickupNotPickupable": { "$sum" : "$score.scorecard.pickup_not_pickupable" },
+                "totalInteractWithNonAgent": { "$sum" : "$score.scorecard.interact_with_non_agent" }
             }
 
             const scoreCardStats = await mcsDB.db.collection(args.eval).aggregate([


### PR DESCRIPTION
Ingest PR here: https://github.com/NextCenturyCorporation/mcs-ingest/pull/98

Making sure all current scorecard fields for Eval 5 are displaying properly in the UI (on scene analysis as well as test overview). Also incorporated the walked_into_structures scorecard field thats still in PR. 

Edit: Realized I should probably add screenshots:

Test overview page:
<img width="1420" alt="Screen Shot 2022-07-07 at 4 10 47 PM" src="https://user-images.githubusercontent.com/7502824/177863187-461b855c-7432-4234-a748-1629ea010ed0.png">

Scene analysis page popup:
<img width="636" alt="Screen Shot 2022-07-07 at 4 07 39 PM" src="https://user-images.githubusercontent.com/7502824/177862789-87a344b4-c1e2-4e4f-af96-73882b2bad61.png">

