### PR TITLE
Query Page Delete and Update

### DIFF
--- a/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
@@ -1,0 +1,104 @@
+import React, {useState} from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+import {useMutation} from 'react-apollo';
+import gql from 'graphql-tag';
+
+const DELETE_QUERY = gql`
+    mutation deleteQuery($_id: String!){
+        deleteQuery(_id: $_id) {
+            _id
+        }
+  }`;
+
+function DeleteQueryModal({show, onHide, selectedQueries, currentUser, totalUserQueries, getSavedQueries, getSavedQueriesName}) {
+    const [deleteQueryCall] = useMutation(DELETE_QUERY, {
+        refetchQueries: [
+          {query: getSavedQueries}, getSavedQueriesName
+        ],
+    });
+
+    const deleteQuery = () => {
+        console.log(selectedQueries[0])
+        selectedQueries.forEach(item => {
+            if (item.query.user.id === currentUser.id) {
+                deleteQueryCall({ variables: {
+                    _id: item.query._id
+                }})
+            }
+        })
+        closeModal()
+    }
+
+    const closeModal = () => {
+        onHide()
+    }
+
+    return (
+        <Modal show={show} onHide={closeModal} size="xl" aria-labelledby="contained-modal-title-vcenter" centered>
+            <Modal.Header closeButton>
+                <Modal.Title id="contained-modal-title-vcenter">Delete ({totalUserQueries}) Queries For User - {currentUser.username}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <table className="delete-query-table">
+                    <thead>
+                        <tr>
+                            <th className='name'>Title</th>
+                            <th className='date'>Date</th>
+                            <th className='comment'>Comment</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {
+                            selectedQueries.map((item, key) =>
+                                (item.query.user.id === currentUser.id) &&
+                                <tr key={'delete_query_row_' + key} id={'delete_query_row_' + key}>
+                                    <td>{item.query.name}</td>
+                                    <td>{(new Date(item.query.createdDate)).toLocaleString()}</td>
+                                    <td>{item.query.description}</td>
+                                </tr>
+                        )}
+                    </tbody>
+                </table>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={closeModal}>Cancel</Button>
+                <Button variant="primary" onClick={deleteQuery}>Confirm Delete {totalUserQueries} Queries (Cannot be Undone)</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+function DeleteQuery ({selectedQueries, currentUser, getSavedQueries, getSavedQueriesName}) {
+
+    const [modalShow, setModalShow] = useState(false);
+
+    const getTotalUserQueries = () => {
+        let count = 0;
+        selectedQueries.forEach( item => count += (item.query.user.id === currentUser.id ? 1 : 0) );
+        return count;
+    }
+
+    return (
+        <>
+            <a href="#deleteQueryLink" onClick={() => setModalShow(true)} className="icon-link">
+                <span className="material-icons icon-margin-left" style={{fontSize: '35px', margin: '-5px'}}>
+                    delete_forever
+                </span>
+            </a>
+
+            <DeleteQueryModal
+                show={modalShow}
+                onHide={() => setModalShow(false)}
+                selectedQueries={selectedQueries}
+                totalUserQueries={getTotalUserQueries()}
+                currentUser={currentUser}
+                getSavedQueries={getSavedQueries}
+                getSavedQueriesName={getSavedQueriesName}
+            />
+        </>
+    );
+    
+}
+
+export default DeleteQuery;

--- a/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
@@ -11,90 +11,110 @@ const DELETE_QUERY = gql`
         }
   }`;
 
-function DeleteQueryModal({show, onHide, selectedQueries, currentUser, totalUserQueries, getSavedQueries, getSavedQueriesName}) {
-    const [deleteQueryCall] = useMutation(DELETE_QUERY, {
+function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, currentUser, getSavedQueries, getSavedQueriesName, clearOrCloseTabsOnDeleteQuery, resetLoadQuerySelections}) {
+    const [deleteQueryCall] = useMutation(DELETE_QUERY, getSavedQueries !== null ? {
         refetchQueries: [
           {query: getSavedQueries}, getSavedQueriesName
         ],
-    });
+    } : {});
 
     const deleteQuery = () => {
-        console.log(selectedQueries[0])
-        selectedQueries.forEach(item => {
-            if (item.query.user.id === currentUser.id) {
-                deleteQueryCall({ variables: {
-                    _id: item.query._id
-                }})
-            }
-        })
-        closeModal()
+        if (deleteFromQueryTabId !== null) {
+            deleteQueryCall({ variables: {
+                _id: deleteFromQueryTabId
+            }})
+            clearOrCloseTabsOnDeleteQuery(deleteFromQueryTabId);
+        }
+        else {
+            selectedQueries.forEach(item => {
+                if (item.query.user.id === currentUser.id) {
+                    deleteQueryCall({ variables: {
+                        _id: item.query._id
+                    }})
+                }
+            })
+            if (resetLoadQuerySelections !== null)
+                resetLoadQuerySelections()
+            clearOrCloseTabsOnDeleteQuery(selectedQueries);
+        }
+        onHide();
     }
 
-    const closeModal = () => {
-        onHide()
+    const getTotalUserQueries = () => {
+        if (deleteFromQueryTabId !== null) 
+            return 'This'
+        let count = 0;
+        selectedQueries.forEach(item => count += (item.query.user.id === currentUser.id ? 1 : 0));
+        return count;
+    }
+
+    const correctQueryString = () => {
+        const totalUserQueries = getTotalUserQueries();
+        return `${totalUserQueries} ${deleteFromQueryTabId !== null || totalUserQueries === 1 ? 'Query' : 'Queries'}`;
     }
 
     return (
-        <Modal show={show} onHide={closeModal} size="xl" aria-labelledby="contained-modal-title-vcenter" centered>
+        <Modal show={show} onHide={onHide} size="xl" aria-labelledby="contained-modal-title-vcenter" centered>
             <Modal.Header closeButton>
-                <Modal.Title id="contained-modal-title-vcenter">Delete ({totalUserQueries}) Queries For User - {currentUser.username}</Modal.Title>
+                <Modal.Title id="contained-modal-title-vcenter">{deleteFromQueryTabId !== null ? "Permanently Delete Currently Selected Query Tab" : `Delete ${correctQueryString()} For User - ${currentUser.username}`}</Modal.Title>
             </Modal.Header>
-            <Modal.Body>
-                <table className="delete-query-table">
-                    <thead>
-                        <tr>
-                            <th className='name'>Title</th>
-                            <th className='date'>Date</th>
-                            <th className='comment'>Comment</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {
-                            selectedQueries.map((item, key) =>
-                                (item.query.user.id === currentUser.id) &&
-                                <tr key={'delete_query_row_' + key} id={'delete_query_row_' + key}>
-                                    <td>{item.query.name}</td>
-                                    <td>{(new Date(item.query.createdDate)).toLocaleString()}</td>
-                                    <td>{item.query.description}</td>
+            {
+                deleteFromQueryTabId === null &&
+                <Modal.Body>
+                        <table className="delete-query-table">
+                            <thead>
+                                <tr>
+                                    <th className='name'>Title</th>
+                                    <th className='date'>Date</th>
+                                    <th className='comment'>Comment</th>
                                 </tr>
-                        )}
-                    </tbody>
-                </table>
-            </Modal.Body>
+                            </thead>
+                            <tbody>
+                                {
+                                    selectedQueries.map((item, key) =>
+                                        (item.query.user.id === currentUser.id) &&
+                                        <tr key={'delete_query_row_' + key} id={'delete_query_row_' + key}>
+                                            <td>{item.query.name}</td>
+                                            <td>{(new Date(item.query.createdDate)).toLocaleString()}</td>
+                                            <td>{item.query.description}</td>
+                                        </tr>
+                                )}
+                            </tbody>
+                        </table>
+                </Modal.Body>
+            }
             <Modal.Footer>
-                <Button variant="secondary" onClick={closeModal}>Cancel</Button>
-                <Button variant="primary" onClick={deleteQuery}>Confirm Delete {totalUserQueries} Queries (Cannot be Undone)</Button>
+                <Button variant="secondary" onClick={onHide}>Cancel</Button>
+                <Button variant="primary" onClick={deleteQuery}>Confirm Delete {correctQueryString()} (Cannot be Undone)</Button>
             </Modal.Footer>
         </Modal>
     );
 }
 
-function DeleteQuery ({selectedQueries, currentUser, getSavedQueries, getSavedQueriesName}) {
+function DeleteQuery ({selectedQueries, deleteFromQueryTabId, currentUser, getSavedQueries, getSavedQueriesName, showText, clearOrCloseTabsOnDeleteQuery, resetLoadQuerySelections}) {
 
     const [modalShow, setModalShow] = useState(false);
 
-    const getTotalUserQueries = () => {
-        let count = 0;
-        selectedQueries.forEach( item => count += (item.query.user.id === currentUser.id ? 1 : 0) );
-        return count;
-    }
 
     return (
         <>
             <a href="#deleteQueryLink" onClick={() => setModalShow(true)} className="icon-link">
-                <span className="material-icons icon-margin-left" style={{fontSize: '35px', margin: '-5px'}}>
+                <span className="material-icons icon-margin-left" style={!showText ? {fontSize: '35px', margin: '-5px'} : {}}>
                     delete_forever
                 </span>
+                { showText && <span className="icon-link-text">Delete</span> }
             </a>
 
             <DeleteQueryModal
                 show={modalShow}
                 onHide={() => setModalShow(false)}
                 selectedQueries={selectedQueries}
-                totalUserQueries={getTotalUserQueries()}
+                deleteFromQueryTabId={deleteFromQueryTabId}
                 currentUser={currentUser}
                 getSavedQueries={getSavedQueries}
                 getSavedQueriesName={getSavedQueriesName}
+                clearOrCloseTabsOnDeleteQuery={clearOrCloseTabsOnDeleteQuery}
+                resetLoadQuerySelections={resetLoadQuerySelections}
             />
         </>
     );

--- a/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 import {useMutation} from 'react-apollo';
@@ -12,6 +12,7 @@ const DELETE_QUERY = gql`
   }`;
 
 function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, currentUser, getSavedQueries, getSavedQueriesName, clearOrCloseTabsOnDeleteQuery, resetLoadQuerySelections}) {
+    const [totalUserQueries, setTotalUserQueries] = useState('');
     const [deleteQueryCall] = useMutation(DELETE_QUERY, getSavedQueries !== null ? {
         refetchQueries: [
           {query: getSavedQueries}, getSavedQueriesName
@@ -41,22 +42,29 @@ function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, 
     }
 
     const getTotalUserQueries = () => {
-        if (deleteFromQueryTabId !== null) 
-            return 'This'
+        if (deleteFromQueryTabId !== null) {
+            setTotalUserQueries('this');
+            return;
+        }
         let count = 0;
         selectedQueries.forEach(item => count += (item.query.user.id === currentUser.id ? 1 : 0));
-        return count;
+        setTotalUserQueries(count);
+        
     }
 
     const correctQueryString = () => {
-        const totalUserQueries = getTotalUserQueries();
         return `${totalUserQueries} ${deleteFromQueryTabId !== null || totalUserQueries === 1 ? 'Query' : 'Queries'}`;
     }
 
+    useEffect(() => {
+        getTotalUserQueries();
+    }, [show])
+
+
     return (
-        <Modal show={show} onHide={onHide} size="xl" aria-labelledby="contained-modal-title-vcenter" centered>
+        <Modal show={show} onHide={onHide} size={deleteFromQueryTabId !== null ? "lg" : "xl"} aria-labelledby="contained-modal-title-vcenter" centered>
             <Modal.Header closeButton>
-                <Modal.Title id="contained-modal-title-vcenter">{deleteFromQueryTabId !== null ? "Permanently Delete Currently Selected Query Tab" : `Delete ${correctQueryString()} For User - ${currentUser.username}`}</Modal.Title>
+                <Modal.Title id="contained-modal-title-vcenter">{deleteFromQueryTabId !== null ? "Permanently Delete this Query?" : `Delete ${correctQueryString()} for User - ${currentUser.username}`}</Modal.Title>
             </Modal.Header>
             {
                 deleteFromQueryTabId === null &&
@@ -85,7 +93,7 @@ function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, 
             }
             <Modal.Footer>
                 <Button variant="secondary" onClick={onHide}>Cancel</Button>
-                <Button variant="primary" onClick={deleteQuery}>Confirm Delete {correctQueryString()} (Cannot be Undone)</Button>
+                <Button variant="primary" onClick={deleteQuery}>Delete {correctQueryString()} (Cannot be Undone)</Button>
             </Modal.Footer>
         </Modal>
     );

--- a/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
@@ -42,7 +42,6 @@ function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, 
     }
 
     const getTotalUserQueries = () => {
-        console.log(selectedQueries)
         if (deleteFromQueryTabId !== null) {
             setTotalUserQueries('this');
             return;

--- a/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/deleteQuery.jsx
@@ -11,7 +11,7 @@ const DELETE_QUERY = gql`
         }
   }`;
 
-function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, currentUser, getSavedQueries, getSavedQueriesName, clearOrCloseTabsOnDeleteQuery, resetLoadQuerySelections}) {
+function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, currentUser, getSavedQueries, getSavedQueriesName, clearOrCloseTabsOnDeleteQuery, resetLoadQuerySelections, setShowDeleteQuery}) {
     const [totalUserQueries, setTotalUserQueries] = useState('');
     const [deleteQueryCall] = useMutation(DELETE_QUERY, getSavedQueries !== null ? {
         refetchQueries: [
@@ -42,6 +42,7 @@ function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, 
     }
 
     const getTotalUserQueries = () => {
+        console.log(selectedQueries)
         if (deleteFromQueryTabId !== null) {
             setTotalUserQueries('this');
             return;
@@ -49,6 +50,7 @@ function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, 
         let count = 0;
         selectedQueries.forEach(item => count += (item.query.user.id === currentUser.id ? 1 : 0));
         setTotalUserQueries(count);
+        setShowDeleteQuery(count > 0);
         
     }
 
@@ -58,7 +60,7 @@ function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, 
 
     useEffect(() => {
         getTotalUserQueries();
-    }, [show])
+    }, [selectedQueries])
 
 
     return (
@@ -99,19 +101,21 @@ function DeleteQueryModal({show, onHide, selectedQueries, deleteFromQueryTabId, 
     );
 }
 
-function DeleteQuery ({selectedQueries, deleteFromQueryTabId, currentUser, getSavedQueries, getSavedQueriesName, showText, clearOrCloseTabsOnDeleteQuery, resetLoadQuerySelections}) {
+function DeleteQuery ({selectedQueries, deleteFromQueryTabId, currentUser, getSavedQueries, getSavedQueriesName, showText, clearOrCloseTabsOnDeleteQuery, resetLoadQuerySelections, showDeleteQuery, setShowDeleteQuery}) {
 
     const [modalShow, setModalShow] = useState(false);
 
-
     return (
         <>
-            <a href="#deleteQueryLink" onClick={() => setModalShow(true)} className="icon-link">
-                <span className="material-icons icon-margin-left" style={!showText ? {fontSize: '35px', margin: '-5px'} : {}}>
-                    delete_forever
-                </span>
-                { showText && <span className="icon-link-text">Delete</span> }
-            </a>
+            {
+                ((resetLoadQuerySelections !== null && showDeleteQuery) || (resetLoadQuerySelections === null)) &&
+                <a href="#deleteQueryLink" onClick={() => setModalShow(true)} className="icon-link">
+                    <span className="material-icons icon-margin-left" style={!showText ? {fontSize: '35px', margin: '-6px', marginRight: '-35px'} : {}}>
+                        delete_forever
+                    </span>
+                    { showText && <span className="icon-link-text">Delete</span> }
+                </a>
+            }
 
             <DeleteQueryModal
                 show={modalShow}
@@ -123,6 +127,7 @@ function DeleteQuery ({selectedQueries, deleteFromQueryTabId, currentUser, getSa
                 getSavedQueriesName={getSavedQueriesName}
                 clearOrCloseTabsOnDeleteQuery={clearOrCloseTabsOnDeleteQuery}
                 resetLoadQuerySelections={resetLoadQuerySelections}
+                setShowDeleteQuery={setShowDeleteQuery}
             />
         </>
     );

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
+import DeleteQuery from './deleteQuery';
 
 const getSavedQueriesName = "getSavedQueries";
 
@@ -41,7 +42,7 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
 
     const manageSelectedQueries = (query, key, remove) => {
         if (remove)
-            setSelectedQueries(selectedQueries.filter(item => key != item.key));
+            setSelectedQueries(selectedQueries.filter(item => key !== item.key));
         else
             setSelectedQueries([...selectedQueries, {'query': query, 'key': key}]);
     }
@@ -66,7 +67,7 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
     }
 
     const isSelected = (key) => {
-        return selectedQueries.some((element) => element.key == key)
+        return selectedQueries.some((element) => element.key === key)
     }
 
     return (
@@ -94,8 +95,9 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                             <div className="load-query-search-load-line">
                                 <LoadQuerySearchBar setSearch={setSearch}/>
                                 <span>
-                                    <a href='#selected' data-toggle="tooltip" 
+                                    <a href='#selected' data-toggle="tooltip" style={{marginRight: '-5px'}}
                                     title='Selecting one query will replace the current query tab. Selecting more than one query will append multiple queries to the end of the tab list.'>({selectedQueries.length}) Selected</a>
+                                    <DeleteQuery selectedQueries={selectedQueries} currentUser={currentUser} getSavedQueries={LOAD_SAVED_QUERIES} getSavedQueriesName={getSavedQueriesName}/>
                                     <button type="button" onClick={() => loadQuery()}>Load Selected</button>
                                 </span>
                             </div>

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -34,6 +34,7 @@ function LoadQueryPage({currentUser, loadQueryHandler, clearOrCloseTabsOnDeleteQ
     const [activeTab, setActiveTab] = useState("load_all_queries");
     const [search, setSearch] = useState("");
     const [selectedQueries, setSelectedQueries] = useState([]);
+    const [showDeleteQuery, setShowDeleteQuery] = useState(false);
 
     const loadQuery = () => {
         let queries = selectedQueries;
@@ -95,10 +96,11 @@ function LoadQueryPage({currentUser, loadQueryHandler, clearOrCloseTabsOnDeleteQ
                             <div className="load-query-search-load-line">
                                 <LoadQuerySearchBar setSearch={setSearch}/>
                                 <span>
-                                    <a href='#selected' data-toggle="tooltip" style={{marginRight: '-5px'}}
+                                    <a href='#selected' data-toggle="tooltip" className={showDeleteQuery ? 'delete-active' : ''}
                                     title='Selecting one query will replace the current query tab. Selecting more than one query will append multiple queries to the end of the tab list.'>({selectedQueries.length}) Selected</a>
                                     <DeleteQuery selectedQueries={selectedQueries} deleteFromQueryTabId={null} currentUser={currentUser} getSavedQueries={LOAD_SAVED_QUERIES} getSavedQueriesName={getSavedQueriesName}
-                                        showText={false} clearOrCloseTabsOnDeleteQuery={clearOrCloseTabsOnDeleteQuery} resetLoadQuerySelections={() => setSelectedQueries([])}/>
+                                        showText={false} clearOrCloseTabsOnDeleteQuery={clearOrCloseTabsOnDeleteQuery} resetLoadQuerySelections={() => setSelectedQueries([])}
+                                        showDeleteQuery={showDeleteQuery} setShowDeleteQuery={setShowDeleteQuery}/>
                                     <button type="button" onClick={() => loadQuery()}>Load Selected</button>
                                 </span>
                             </div>

--- a/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/loadQuery.jsx
@@ -30,7 +30,7 @@ function LoadQuerySearchBar({setSearch}) {
     )
 }
     
-function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
+function LoadQueryPage({currentUser, loadQueryHandler, clearOrCloseTabsOnDeleteQuery}) {
     const [activeTab, setActiveTab] = useState("load_all_queries");
     const [search, setSearch] = useState("");
     const [selectedQueries, setSelectedQueries] = useState([]);
@@ -97,7 +97,8 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
                                 <span>
                                     <a href='#selected' data-toggle="tooltip" style={{marginRight: '-5px'}}
                                     title='Selecting one query will replace the current query tab. Selecting more than one query will append multiple queries to the end of the tab list.'>({selectedQueries.length}) Selected</a>
-                                    <DeleteQuery selectedQueries={selectedQueries} currentUser={currentUser} getSavedQueries={LOAD_SAVED_QUERIES} getSavedQueriesName={getSavedQueriesName}/>
+                                    <DeleteQuery selectedQueries={selectedQueries} deleteFromQueryTabId={null} currentUser={currentUser} getSavedQueries={LOAD_SAVED_QUERIES} getSavedQueriesName={getSavedQueriesName}
+                                        showText={false} clearOrCloseTabsOnDeleteQuery={clearOrCloseTabsOnDeleteQuery} resetLoadQuerySelections={() => setSelectedQueries([])}/>
                                     <button type="button" onClick={() => loadQuery()}>Load Selected</button>
                                 </span>
                             </div>
@@ -149,11 +150,12 @@ function LoadQueryPage({show, onHide, currentUser, loadQueryHandler}) {
     );
 }
 
-function LoadQuery ({currentUser, loadQueryHandler}) {
+function LoadQuery ({currentUser, loadQueryHandler, clearOrCloseTabsOnDeleteQuery}) {
     return (
         <LoadQueryPage
             currentUser = {currentUser}
             loadQueryHandler = {loadQueryHandler}
+            clearOrCloseTabsOnDeleteQuery = {clearOrCloseTabsOnDeleteQuery}
         />
     );
     

--- a/analysis-ui/src/components/QueryBuilder/queryBuilder.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryBuilder.jsx
@@ -3,6 +3,7 @@ import QueryLineItem from './queryLine';
 import QueryResults from './queryResults';
 import SaveQuery from './saveQuery';
 import CancelPresentation from '@material-ui/icons/CancelPresentation';
+import DeleteQuery from './deleteQuery';
 
 const ParamDisplayByOperator =({queryLine}) => {
     if(queryLine.functionOperator === "between" || queryLine.functionOperator === "and" || queryLine.functionOperator === "or") {
@@ -40,7 +41,7 @@ class ComplexQueryBuilder extends React.Component {
     }
 
     clearQuery = () => {
-        this.props.updateQueryObjForTab([], null, null, this.props.queryId, "Query " + this.props.queryId, "");
+        this.props.updateQueryObjForTab([], null, null, this.props.queryId, "Query " + this.props.queryId, "", "", {});
     }
 
     removeQueryRow = (key) => {
@@ -67,18 +68,21 @@ class ComplexQueryBuilder extends React.Component {
                 <div className="query-controls">
                     <SaveQuery queryObj={this.props.saveQueryObject} currentUser={this.props.currentUser}
                         queryId={this.props.queryId} updateQueryNameHandler={this.props.updateQueryNameHandler} sortBy={this.props.sortBy} groupBy={this.props.groupBy}/>
-                    <a href="#updateQueryLink" onClick={() => console.log("Update")} className="icon-link">
-                        <span className="material-icons icon-margin-left">update</span>
-                        <span className="icon-link-text">Update</span>
-                    </a>
                     <a href="#clearQueryLink" onClick={this.clearQuery} className="icon-link">
                         <span className="material-icons icon-margin-left">settings_backup_restore</span>
                         <span className="icon-link-text">Clear</span>
                     </a>
-                    <a href="#deleteQueryLink" onClick={() => console.log("Delete")} className="icon-link">
-                        <span className="material-icons icon-margin-left">delete_forever</span>
-                        <span className="icon-link-text">Delete</span>
-                    </a>
+                    {this.props.currentUser !== null && this.props.currentUser.id === this.props.queryUserId &&
+                        <>
+                            <a href="#updateQueryLink" onClick={() => console.log("Update")} className="icon-link">
+                                <span className="material-icons icon-margin-left">update</span>
+                                <span className="icon-link-text">Update</span>
+                            </a>
+                            <DeleteQuery selectedQueries={[]} deleteFromQueryTabId={this.props.currentTabMongoId} currentUser={this.props.currentUser}
+                                getSavedQueries={null} getSavedQueriesName={null} showText={true} clearOrCloseTabsOnDeleteQuery={this.props.clearOrCloseTabsOnDeleteQuery}
+                                resetLoadQuerySelections={null}/>
+                        </>
+                    }
                     {this.props.numberTabs > 1 && 
                         <a href="#closeTabLink" onClick={this.closeTab} className="icon-link close-tab-link">
                             <CancelPresentation/>

--- a/analysis-ui/src/components/QueryBuilder/queryBuilder.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryBuilder.jsx
@@ -67,9 +67,17 @@ class ComplexQueryBuilder extends React.Component {
                 <div className="query-controls">
                     <SaveQuery queryObj={this.props.saveQueryObject} currentUser={this.props.currentUser}
                         queryId={this.props.queryId} updateQueryNameHandler={this.props.updateQueryNameHandler} sortBy={this.props.sortBy} groupBy={this.props.groupBy}/>
+                    <a href="#updateQueryLink" onClick={() => console.log("Update")} className="icon-link">
+                        <span className="material-icons icon-margin-left">update</span>
+                        <span className="icon-link-text">Update</span>
+                    </a>
                     <a href="#clearQueryLink" onClick={this.clearQuery} className="icon-link">
                         <span className="material-icons icon-margin-left">settings_backup_restore</span>
                         <span className="icon-link-text">Clear</span>
+                    </a>
+                    <a href="#deleteQueryLink" onClick={() => console.log("Delete")} className="icon-link">
+                        <span className="material-icons icon-margin-left">delete_forever</span>
+                        <span className="icon-link-text">Delete</span>
                     </a>
                     {this.props.numberTabs > 1 && 
                         <a href="#closeTabLink" onClick={this.closeTab} className="icon-link close-tab-link">

--- a/analysis-ui/src/components/QueryBuilder/queryBuilder.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryBuilder.jsx
@@ -4,6 +4,7 @@ import QueryResults from './queryResults';
 import SaveQuery from './saveQuery';
 import CancelPresentation from '@material-ui/icons/CancelPresentation';
 import DeleteQuery from './deleteQuery';
+import UpdateQuery from './updateQuery';
 
 const ParamDisplayByOperator =({queryLine}) => {
     if(queryLine.functionOperator === "between" || queryLine.functionOperator === "and" || queryLine.functionOperator === "or") {
@@ -74,10 +75,9 @@ class ComplexQueryBuilder extends React.Component {
                     </a>
                     {this.props.currentUser !== null && this.props.currentUser.id === this.props.queryUserId &&
                         <>
-                            <a href="#updateQueryLink" onClick={() => console.log("Update")} className="icon-link">
-                                <span className="material-icons icon-margin-left">update</span>
-                                <span className="icon-link-text">Update</span>
-                            </a>
+                            <UpdateQuery queryName={this.props.name} queryDescription={this.props.description} queryObj={this.props.saveQueryObject}
+                                queryMongoId={this.props.queryMongoId} updateTabsOnUpdateQuery={this.props.updateTabsOnUpdateQuery} 
+                                groupBy={this.props.groupBy} sortBy={this.props.sortBy}/>
                             <DeleteQuery selectedQueries={[]} deleteFromQueryTabId={this.props.currentTabMongoId} currentUser={this.props.currentUser}
                                 getSavedQueries={null} getSavedQueriesName={null} showText={true} clearOrCloseTabsOnDeleteQuery={this.props.clearOrCloseTabsOnDeleteQuery}
                                 resetLoadQuerySelections={null}/>

--- a/analysis-ui/src/components/QueryBuilder/queryPage.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryPage.jsx
@@ -14,7 +14,8 @@ class QueryPage extends React.Component {
                 tabQueryObj: [],
                 groupBy: {value: "", label: ""},
                 sortBy: {property: "", sortOrder: "desc"},
-                mongoId: ""
+                mongoId: "",
+                userId: ""
             }],
             currentTab: 1,
             totalTab: 1,
@@ -28,6 +29,7 @@ class QueryPage extends React.Component {
         this.loadQueryHandler = this.loadQueryHandler.bind(this);
         this.updateQueryObjForTab = this.updateQueryObjForTab.bind(this);
         this.closeQueryTab = this.closeQueryTab.bind(this);
+        this.clearOrCloseTabsOnDeleteQuery = this.clearOrCloseTabsOnDeleteQuery.bind(this);
 
         if(this.props !== null & this.props.currentUser !== null) {
             if(this.props.currentUser.queryBuilderState !== undefined && this.props.currentUser.queryBuilderState !== null) {
@@ -43,7 +45,8 @@ class QueryPage extends React.Component {
             tabQueryObj: [],
             groupBy: {value: "", label: ""},
             sortBy: {property: "", sortOrder: "desc"},
-            mongoId: ""
+            mongoId: "",
+            userId: ""
         });
 
         this.setState({ 
@@ -63,7 +66,8 @@ class QueryPage extends React.Component {
                 tabQueryObj: [],
                 groupBy: {value: "", label: ""},
                 sortBy: {property: "", sortOrder: "desc"},
-                mongoId: ""
+                mongoId: "",
+                userId: ""
             })
         }
         let newArray = this.state.queryTabs.concat(additionalTabs);
@@ -81,17 +85,18 @@ class QueryPage extends React.Component {
         this.setState({ 
             queryTabs: newArray,
             currentTab: newCurrentTab,
-            currentTabMongoId: newArray[newCurrentTab-1].mongoId
+            currentTabMongoId: newArray.length > 0 ? newArray[newCurrentTab-1].mongoId : ""
         })
         this.props.currentUser["queryBuilderState"] = this.state;
     }
 
-    updateQueryNameHandler = (queryId, newQueryName, queryMongoId) => {
+    updateQueryNameHandler = (queryId, newQueryName, queryMongoId, userId) => {
         let newArray = this.state.queryTabs.concat();
         for(let i=0; i < newArray.length; i++) {
             if(newArray[i].id === queryId) {
                 newArray[i].name = newQueryName;
                 newArray[i].mongoId = queryMongoId;
+                newArray[i].userId = userId
             }
         }
 
@@ -109,7 +114,7 @@ class QueryPage extends React.Component {
             let queryObj = queryObjects[i]['query']
             queryObj.groupBy = queryObj.groupBy === undefined ||  queryObj.groupBy === null || queryObj.groupBy === "" ? {value: "", label: "None"} : queryObj.groupBy;
             queryObj.sortBy = queryObj.sortBy === null || queryObj.sortBy === undefined || queryObj.sortBy === "" ? {property: "", sortOrder: "desc"} : queryObj.sortBy;
-            this.updateQueryObjForTab(queryObj.queryObj, queryObj.groupBy, queryObj.sortBy, this.state.currentTab, queryObj.name, queryObj._id);
+            this.updateQueryObjForTab(queryObj.queryObj, queryObj.groupBy, queryObj.sortBy, this.state.currentTab, queryObj.name, queryObj._id, queryObj.user.id);
             if(this.queryResultsTableRef.current !== null) {
                 this.queryResultsTableRef.current.updateTableGroupAndSortBy(queryObj.groupBy, queryObj.sortBy);
             }
@@ -128,7 +133,7 @@ class QueryPage extends React.Component {
         this.updateQueryState(newArray);
     }
 
-    updateQueryObjForTab = (queryObj, groupBy, sortBy, queryId, tabName, mongoQueryId) => {
+    updateQueryObjForTab = (queryObj, groupBy, sortBy, queryId, tabName, mongoQueryId, userId) => {
         let newArray = this.state.queryTabs.concat();
         for(let i=0; i < newArray.length; i++) {
             if(newArray[i].id === queryId) {
@@ -138,6 +143,7 @@ class QueryPage extends React.Component {
                 if(tabName !== undefined) {
                     newArray[i].name = tabName;
                     newArray[i].mongoId = mongoQueryId;
+                    newArray[i].userId = userId;
                 }
             }
         }
@@ -174,27 +180,45 @@ class QueryPage extends React.Component {
         this.props.currentUser["queryBuilderState"] = this.state;
     }
 
-    closeQueryTab = (queryId) => {
+    closeQueryTab = async (queryId, calledFromDeleteQuery=false) => {
         let newArray = this.state.queryTabs.concat();
         let newCurrentTab = this.state.currentTab;
-        for(let i=0; i < newArray.length; i++) {
-            if(newArray[i].id === queryId) {
-                newArray.splice(i, 1);
-                this.setState({totalTab: this.state.totalTab-1});
+        for(let i=newArray.length-1; i >= 0; i--) {
+            if(newArray[i].id === queryId || (calledFromDeleteQuery && newArray[i].mongoId === queryId)) {
+                if (newArray.length <= 1) {
+                    this.updateQueryObjForTab([], null, null, 1, "Query " + 1, "", "", {})
+                }
+                else {
+                    newArray.splice(i, 1);
+                }
             }
         }
+
+        this.setState({totalTab: newArray.length});
         
         if(newArray.length>0) {
             for(let i=0; i < newArray.length; i++) {
                 newArray[i].id = i + 1;
             }
         }
-
-        if(newCurrentTab === queryId) {
+        
+        if (calledFromDeleteQuery)
             newCurrentTab = newArray[0].id;
-        }
-
+        else if(newCurrentTab === queryId)
+            newCurrentTab = newArray[0].id;
+        
         this.updateQueryState(newArray, newCurrentTab);
+    }
+
+    clearOrCloseTabsOnDeleteQuery = async (selectedQueries) => {
+        console.log(selectedQueries)
+        if (typeof selectedQueries === "string")
+            this.closeQueryTab(selectedQueries, true);
+        else {
+            for (const query of selectedQueries) {
+                await this.closeQueryTab(query.query._id, true);
+            }
+        }
     }
 
     showLoadQuery = () => {
@@ -233,14 +257,14 @@ class QueryPage extends React.Component {
                     </div>
                 </div>
                 <div className="query-tab-contents">
-                    {this.state.showLoadQuery && <LoadQuery currentUser={this.props.currentUser} loadQueryHandler={this.loadQueryHandler}/>}
+                    {this.state.showLoadQuery && <LoadQuery currentUser={this.props.currentUser} loadQueryHandler={this.loadQueryHandler} clearOrCloseTabsOnDeleteQuery={this.clearOrCloseTabsOnDeleteQuery}/>}
                     {!this.state.showLoadQuery && this.state.queryTabs.map((tabObj, key) => 
                         <div key={'query_tab_' + key} className={tabObj.id === this.state.currentTab ? null : 'd-none'}>
-                            <ComplexQueryBuilder queryId={tabObj.id} saveQueryObject={tabObj.tabQueryObj} currentUser={this.props.currentUser} 
+                            <ComplexQueryBuilder queryId={tabObj.id} queryUserId={tabObj.userId} saveQueryObject={tabObj.tabQueryObj} currentUser={this.props.currentUser} currentTabMongoId={this.state.currentTabMongoId}
                                 updateQueryNameHandler={this.updateQueryNameHandler} updateQueryObjForTab={this.updateQueryObjForTab} numberTabs={this.state.queryTabs.length}
                                 closeQueryTab={this.closeQueryTab} tabId={tabObj.id} currentTab={this.state.currentTab} queryMongoId={tabObj.mongoId} name={tabObj.name}
                                 setTableSortBy={this.setTableSortBy} sortBy={tabObj.sortBy} setGroupBy={this.setGroupBy} groupBy={tabObj.groupBy} queryResultsTableRef={this.queryResultsTableRef}
-                                client={this.props.client}/>
+                                client={this.props.client} clearOrCloseTabsOnDeleteQuery={this.clearOrCloseTabsOnDeleteQuery}/>
                         </div>
                     )}
                 </div>   

--- a/analysis-ui/src/components/QueryBuilder/queryPage.jsx
+++ b/analysis-ui/src/components/QueryBuilder/queryPage.jsx
@@ -10,7 +10,8 @@ class QueryPage extends React.Component {
         this.state = {
             queryTabs: [{
                 id: 1, 
-                name: "Query 1", 
+                name: "Query 1",
+                description: "",
                 tabQueryObj: [],
                 groupBy: {value: "", label: ""},
                 sortBy: {property: "", sortOrder: "desc"},
@@ -30,6 +31,7 @@ class QueryPage extends React.Component {
         this.updateQueryObjForTab = this.updateQueryObjForTab.bind(this);
         this.closeQueryTab = this.closeQueryTab.bind(this);
         this.clearOrCloseTabsOnDeleteQuery = this.clearOrCloseTabsOnDeleteQuery.bind(this);
+        this.updateTabsOnUpdateQuery = this.updateTabsOnUpdateQuery.bind(this);
 
         if(this.props !== null & this.props.currentUser !== null) {
             if(this.props.currentUser.queryBuilderState !== undefined && this.props.currentUser.queryBuilderState !== null) {
@@ -42,6 +44,7 @@ class QueryPage extends React.Component {
         let newArray = this.state.queryTabs.concat({
             id: this.state.totalTab+1, 
             name: "Query " + (this.state.totalTab+1),
+            description: "",
             tabQueryObj: [],
             groupBy: {value: "", label: ""},
             sortBy: {property: "", sortOrder: "desc"},
@@ -63,6 +66,7 @@ class QueryPage extends React.Component {
             additionalTabs.push({
                 id: this.state.totalTab + (i - this.state.totalTab), 
                 name: "Query " + (this.state.totalTab + (i - this.state.totalTab)),
+                description: "",
                 tabQueryObj: [],
                 groupBy: {value: "", label: ""},
                 sortBy: {property: "", sortOrder: "desc"},
@@ -90,11 +94,12 @@ class QueryPage extends React.Component {
         this.props.currentUser["queryBuilderState"] = this.state;
     }
 
-    updateQueryNameHandler = (queryId, newQueryName, queryMongoId, userId) => {
+    updateQueryNameHandler = (queryId, newQueryName, queryMongoId, userId, newQueryDescription) => {
         let newArray = this.state.queryTabs.concat();
         for(let i=0; i < newArray.length; i++) {
             if(newArray[i].id === queryId) {
                 newArray[i].name = newQueryName;
+                newArray[i].description = newQueryDescription;
                 newArray[i].mongoId = queryMongoId;
                 newArray[i].userId = userId
             }
@@ -114,7 +119,7 @@ class QueryPage extends React.Component {
             let queryObj = queryObjects[i]['query']
             queryObj.groupBy = queryObj.groupBy === undefined ||  queryObj.groupBy === null || queryObj.groupBy === "" ? {value: "", label: "None"} : queryObj.groupBy;
             queryObj.sortBy = queryObj.sortBy === null || queryObj.sortBy === undefined || queryObj.sortBy === "" ? {property: "", sortOrder: "desc"} : queryObj.sortBy;
-            this.updateQueryObjForTab(queryObj.queryObj, queryObj.groupBy, queryObj.sortBy, this.state.currentTab, queryObj.name, queryObj._id, queryObj.user.id);
+            this.updateQueryObjForTab(queryObj.queryObj, queryObj.groupBy, queryObj.sortBy, this.state.currentTab, queryObj.name, queryObj._id, queryObj.user.id, queryObj.description);
             if(this.queryResultsTableRef.current !== null) {
                 this.queryResultsTableRef.current.updateTableGroupAndSortBy(queryObj.groupBy, queryObj.sortBy);
             }
@@ -133,15 +138,18 @@ class QueryPage extends React.Component {
         this.updateQueryState(newArray);
     }
 
-    updateQueryObjForTab = (queryObj, groupBy, sortBy, queryId, tabName, mongoQueryId, userId) => {
+    updateQueryObjForTab = (queryObj, groupBy, sortBy, queryId, tabName, mongoQueryId, userId, tabDescription) => {
         let newArray = this.state.queryTabs.concat();
         for(let i=0; i < newArray.length; i++) {
-            if(newArray[i].id === queryId) {
-                newArray[i].tabQueryObj = queryObj;
-                newArray[i].groupBy = groupBy === null || groupBy === undefined || groupBy === "" ? {value: "", label: "None"} : groupBy
-                newArray[i].sortBy = sortBy === null || sortBy === undefined || sortBy === "" ? {property: "", sortOrder: "desc"} : sortBy
+            if((queryId === -1 && newArray[i].mongoId === mongoQueryId) || (newArray[i].id === queryId)) {
+                if (queryObj !== null) {
+                    newArray[i].tabQueryObj = queryObj;
+                    newArray[i].groupBy = groupBy === null || groupBy === undefined || groupBy === "" ? {value: "", label: "None"} : groupBy
+                    newArray[i].sortBy = sortBy === null || sortBy === undefined || sortBy === "" ? {property: "", sortOrder: "desc"} : sortBy
+                }
                 if(tabName !== undefined) {
                     newArray[i].name = tabName;
+                    newArray[i].description = tabDescription;
                     newArray[i].mongoId = mongoQueryId;
                     newArray[i].userId = userId;
                 }
@@ -211,7 +219,6 @@ class QueryPage extends React.Component {
     }
 
     clearOrCloseTabsOnDeleteQuery = async (selectedQueries) => {
-        console.log(selectedQueries)
         if (typeof selectedQueries === "string")
             this.closeQueryTab(selectedQueries, true);
         else {
@@ -219,6 +226,10 @@ class QueryPage extends React.Component {
                 await this.closeQueryTab(query.query._id, true);
             }
         }
+    }
+
+    updateTabsOnUpdateQuery = (queryObj, groupBy, sortBy, tabName, tabDescription, mongoQueryId) => {
+        this.updateQueryObjForTab(queryObj, groupBy, sortBy, -1, tabName, mongoQueryId, this.props.currentUser.id, tabDescription)
     }
 
     showLoadQuery = () => {
@@ -262,9 +273,9 @@ class QueryPage extends React.Component {
                         <div key={'query_tab_' + key} className={tabObj.id === this.state.currentTab ? null : 'd-none'}>
                             <ComplexQueryBuilder queryId={tabObj.id} queryUserId={tabObj.userId} saveQueryObject={tabObj.tabQueryObj} currentUser={this.props.currentUser} currentTabMongoId={this.state.currentTabMongoId}
                                 updateQueryNameHandler={this.updateQueryNameHandler} updateQueryObjForTab={this.updateQueryObjForTab} numberTabs={this.state.queryTabs.length}
-                                closeQueryTab={this.closeQueryTab} tabId={tabObj.id} currentTab={this.state.currentTab} queryMongoId={tabObj.mongoId} name={tabObj.name}
+                                closeQueryTab={this.closeQueryTab} tabId={tabObj.id} currentTab={this.state.currentTab} queryMongoId={tabObj.mongoId} name={tabObj.name} description={tabObj.description}
                                 setTableSortBy={this.setTableSortBy} sortBy={tabObj.sortBy} setGroupBy={this.setGroupBy} groupBy={tabObj.groupBy} queryResultsTableRef={this.queryResultsTableRef}
-                                client={this.props.client} clearOrCloseTabsOnDeleteQuery={this.clearOrCloseTabsOnDeleteQuery}/>
+                                client={this.props.client} clearOrCloseTabsOnDeleteQuery={this.clearOrCloseTabsOnDeleteQuery} updateTabsOnUpdateQuery={this.updateTabsOnUpdateQuery}/>
                         </div>
                     )}
                 </div>   

--- a/analysis-ui/src/components/QueryBuilder/saveQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/saveQuery.jsx
@@ -34,7 +34,7 @@ function SaveQueryModal({show, onHide, queryObj, currentUser, queryId, updateQue
             description: queryDesc,
             createdDate: (new Date()).valueOf()
         } }).then((result) => {
-            updateQueryNameHandler(queryId, queryName, result.data[SAVE_QUERY_NAME]["_id"], currentUser.id);
+            updateQueryNameHandler(queryId, queryName, result.data[SAVE_QUERY_NAME]["_id"], currentUser.id, queryDesc);
             resetSaveForm();
             onHide();
         });

--- a/analysis-ui/src/components/QueryBuilder/saveQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/saveQuery.jsx
@@ -34,7 +34,7 @@ function SaveQueryModal({show, onHide, queryObj, currentUser, queryId, updateQue
             description: queryDesc,
             createdDate: (new Date()).valueOf()
         } }).then((result) => {
-            updateQueryNameHandler(queryId, queryName, result.data[SAVE_QUERY_NAME]["_id"]);
+            updateQueryNameHandler(queryId, queryName, result.data[SAVE_QUERY_NAME]["_id"], currentUser.id);
             resetSaveForm();
             onHide();
         });

--- a/analysis-ui/src/components/QueryBuilder/updateQuery.jsx
+++ b/analysis-ui/src/components/QueryBuilder/updateQuery.jsx
@@ -1,0 +1,139 @@
+import React, {useState, useEffect} from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+import {useMutation} from 'react-apollo';
+import gql from 'graphql-tag';
+import Check from 'react-bootstrap/FormCheck';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
+const UPDATE_QUERY_NAME = "updateQuery";
+const UPDATE_QUERY = gql`
+    mutation updateQuery($queryObj: JSON!, $groupBy: JSON!, $sortBy: JSON!, $name: String!, $description: String!, $createdDate: Float!, $_id: String!) {
+        updateQuery(queryObj: $queryObj,  groupBy: $groupBy, sortBy: $sortBy, name: $name, description: $description, createdDate: $createdDate, _id: $_id) {
+            name
+            description
+            createdDate
+            _id
+        }
+  }`;
+
+  const UPDATE_QUERY_NAME_AND_DESCRIPTION_ONLY_NAME = "updateQueryNameAndDescriptionOnly";
+  const UPDATE_QUERY_NAME_AND_DESCRIPTION_ONLY = gql`
+      mutation updateQueryNameAndDescriptionOnly($name: String!, $description: String!, $createdDate: Float!, $_id: String!) {
+          updateQueryNameAndDescriptionOnly(name: $name, description: $description, createdDate: $createdDate, _id: $_id) {
+              name
+              description
+              createdDate
+              _id
+          }
+    }`;
+
+function UpdateQueryModal({show, onHide, queryObj, queryName, queryDescription, queryMongoId, updateTabsOnUpdateQuery, groupBy, sortBy}) {
+    const [updatedQueryName, setQueryName] = useState(queryName);
+    const [updatedQueryDescription, setQueryDesc] = useState(queryDescription);
+    const [updateQueryCall] = useMutation(UPDATE_QUERY);
+    const [updateQueryNameAndDescriptionOnlyCall] = useMutation(UPDATE_QUERY_NAME_AND_DESCRIPTION_ONLY);
+    const [updateQueryContents, setUpdateQueryContents] = useState(true)
+
+    const resetUpdateForm = () => {
+        setQueryName(queryName);
+        setQueryDesc(queryDescription);
+        setUpdateQueryContents(true);
+    }
+
+    const updateQuery = () => {
+        if (updateQueryContents) {
+            updateQueryCall({ variables: {
+                _id: queryMongoId,
+                queryObj: queryObj,
+                groupBy: groupBy,
+                sortBy: sortBy,
+                name: updatedQueryName,
+                description: updatedQueryDescription,
+                createdDate: (new Date()).valueOf()
+            } })
+            updateTabsOnUpdateQuery(queryObj, groupBy, sortBy, updatedQueryName, updatedQueryDescription, queryMongoId);
+        }
+        else {
+            updateQueryNameAndDescriptionOnlyCall({ variables: {
+                _id: queryMongoId,
+                name: updatedQueryName,
+                description: updatedQueryDescription,
+                createdDate: (new Date()).valueOf()
+            } })
+            updateTabsOnUpdateQuery(null, null, null, updatedQueryName, updatedQueryDescription, queryMongoId);
+        }
+        resetUpdateForm();
+        onHide();
+    };
+
+    const closeModal = () => {
+        resetUpdateForm();
+        onHide();
+    }
+
+    const renderTooltip = (props) => (
+        <Tooltip id="button-tooltip" {...props}>
+          Toggle off to only update the name and description
+        </Tooltip>
+      );
+
+    return (
+        <Modal show={show} onHide={closeModal} size="lg" aria-labelledby="contained-modal-title-vcenter" centered>
+            <Modal.Header closeButton>
+                <Modal.Title id="contained-modal-title-vcenter">Update Query</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <form>
+                    <div className="form-group">
+                        <div className="input-login-header">Name</div>
+                        <input className="form-control form-control-lg" placeholder="Query Name" type="text" value={updatedQueryName} list="name-recomendations" 
+                            onChange={(e) => setQueryName(e.target.value)}/>
+                    </div>
+                    <div className="form-group">
+                        <div className="input-login-header">Description</div>
+                        <input className="form-control form-control-lg" placeholder="Query Description" type="text" value={updatedQueryDescription} list="name-recomendations" 
+                            onChange={(e) => setQueryDesc(e.target.value)}/>
+                    </div>
+                    <OverlayTrigger placement="left" delay={{ show: 50, hide: 200 }} overlay={renderTooltip}>
+                        <Check onClick={() => setUpdateQueryContents(!updateQueryContents)} checked={updateQueryContents} type="switch" id="custom-switch" label="Update Query Contents"/>
+                    </OverlayTrigger>
+                </form>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={closeModal}>Cancel</Button>
+                <Button variant="primary" onClick={updateQuery}>Update Query</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+function UpdateQuery ({queryObj, queryName, queryDescription, queryMongoId, updateTabsOnUpdateQuery, groupBy, sortBy}) {
+
+    const [modalShow, setModalShow] = React.useState(false);
+
+    return (
+        <>
+            <a href="#updateQueryLink" onClick={() => setModalShow(true)} className="icon-link">
+                <span className="material-icons icon-margin-left">update</span>
+                <span className="icon-link-text">Update</span>
+            </a>
+
+            <UpdateQueryModal
+                show={modalShow}
+                onHide={() => setModalShow(false)}
+                queryObj={queryObj}
+                queryName={queryName}
+                queryDescription={queryDescription} 
+                queryMongoId={queryMongoId}
+                updateTabsOnUpdateQuery={updateTabsOnUpdateQuery}
+                groupBy={groupBy}
+                sortBy={sortBy}
+            />
+        </>
+    );
+    
+}
+
+export default UpdateQuery;

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -865,6 +865,7 @@ ol, ul {
     border: solid 1px #0a7bc6;
     background-color: #58abff;
     color: white;
+    margin-left: -35px
 }
 
 .query-tab-controls button {
@@ -981,7 +982,8 @@ ol, ul {
     width: 95%;
 }
 
-.load-query-table {
+
+.load-query-table, .delete-query-table {
     border-collapse: collapse;
     margin: 1px 40px;
     font-size: 0.9em;
@@ -991,7 +993,11 @@ ol, ul {
     display: block;
 }
 
-.load-query-table thead tr {
+.delete-query-table {
+    height: 40vh;
+}
+
+.load-query-table thead tr, .delete-query-table thead tr {
     text-align: left;
     font-weight: bold;
     text-decoration: 1.5px underline;
@@ -999,24 +1005,24 @@ ol, ul {
     text-underline-offset: 2px;
 }
 
-.load-query-table tr {
+.load-query-table tr, .delete-query-table tr {
     cursor: default;
 }
 
-.load-query-table th, .load-query-table td {
+.load-query-table th, .load-query-table td, .delete-query-table th, .delete-query-table td {
     padding: 12px 15px;
     text-align: left;
     border: 0px solid;
 }
 
-.load-query-table th {
+.load-query-table th, .delete-query-table th {
     position: sticky;
     top: 0;
     z-index: 1;
     background-color: white;
 }
 
-.load-query-table th::after {
+.load-query-table th::after, .delete-query-table th::after {
     content: '';
     width: 100%;
     height: 0.1px;
@@ -1026,7 +1032,7 @@ ol, ul {
     background: rgb(174, 174, 174);
 }
 
-.load-query-table td {
+.load-query-table td, .delete-query-table td {
     padding: 12px 15px;
     border-bottom: 1px solid rgb(174, 174, 174)
 }
@@ -1051,7 +1057,7 @@ ol, ul {
     background-color: #aad2ee75 !important;
 }
 
-.load-query-table tbody tr:nth-child(even) {
+.load-query-table tbody tr:nth-child(even), .delete-query-table tbody tr:nth-child(even) {
     background-color: #f3f3f3cb;
 }
 
@@ -1067,15 +1073,15 @@ ol, ul {
     column-width: 1vw;
 }
 
-.load-query-table .name {
+.load-query-table .name, .delete-query-table .name {
     column-width: 50vw;
 }
 
-.load-query-table .date {
+.load-query-table .date, .delete-query-table .date {
     column-width: 10vw;
 }
 
-.load-query-table .comment {
+.load-query-table .comment, .delete-query-table .comment {
     column-width: 28vw;
 }
 

--- a/analysis-ui/src/css/app.css
+++ b/analysis-ui/src/css/app.css
@@ -850,8 +850,12 @@ ol, ul {
 }
 
 .load-query-search-load-line a {
-    margin: 7.5px 15px;
+    margin: 7.5px 45px;
     color: grey;
+}
+
+.load-query-search-load-line a.delete-active {
+    margin: 7.5px -35px;
 }
 
 .load-query-search-load-line a:hover {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -153,7 +153,8 @@ const mcsTypeDefs = gql`
     updateSceneHistoryRemoveFlag(catTypePair: String, testNum: Int, flagRemove: Boolean) : updateObject
     updateSceneHistoryInterestFlag(catTypePair: String, testNum: Int, flagInterest: Boolean) : updateObject
     saveQuery(user: JSON, queryObj: JSON, groupBy: JSON, sortBy: JSON, name: String, description: String, createdDate: Float) : savedQueryObj
-    updateQuery(queryObj: JSON, groupBy: JSON, sortBy: JSON, name: String, description: String, createdData: Float, _id: String) : savedQueryObj
+    updateQuery(queryObj: JSON, groupBy: JSON, sortBy: JSON, name: String, description: String, createdDate: Float, _id: String) : savedQueryObj
+    updateQueryNameAndDescriptionOnly(name: String, description: String, createdDate: Float, _id: String) : savedQueryObj
     deleteQuery(_id: String) : savedQueryObj
     setEvalStatusParameters(eval: String, evalStatusParams: JSON) : JSON
     createCSV(collectionName: String, eval: String): JSON
@@ -615,6 +616,13 @@ const mcsResolvers = {
                 queryObj: args["queryObj"],
                 groupBy: args["groupBy"],
                 sortBy: args["sortBy"],
+                name: args["name"],
+                description: args["description"],
+                createdDate: args["createdDate"]
+            }});
+        },
+        updateQueryNameAndDescriptionOnly: async (obj, args, context, infow) => {
+            return await mcsDB.db.collection('savedQueries').update({_id: mongoDb.ObjectID(args["_id"])}, {$set: {
                 name: args["name"],
                 description: args["description"],
                 createdDate: args["createdDate"]


### PR DESCRIPTION
You can delete multiple queries from load query if they are tied to your account. Once a query tab is loaded, if that query is tied to your account you can update or delete it alongside clearing it and saving a new one. 

Updating gives you the option to only change the name and description but not the contents if you want. This is so you can add or remove properties from your query and change the groupby and sortby without overwriting those when you update. I found this is more useful for changing groupby and sortby. 

Active query tabs that are tied to the same mongo id as the query  being updated or deleted will be modified accordingly. So if I had 10 tabs loaded and open for the query "Jacob Test 1" and deleted that query from the load query delete modal, all of those tabs will be closed. This will also happen if I delete it from the query tab's single delete modal too. Updating one of those "Jacob Test 1" tabs will also update all of the other open tabs with the same mongoId.