### PR TITLE
MCS-1135:  Update any 'retrieval' checks to include 'multi retrieval'

### DIFF
--- a/analysis-ui/src/components/TestOverview/overview.jsx
+++ b/analysis-ui/src/components/TestOverview/overview.jsx
@@ -170,7 +170,7 @@ class TestOverview extends React.Component {
                                                         </li>
                                                     }
                                                     {/* Exclude Evaluation 3 Results because we didn't have scorecard functionality yet */}
-                                                    {((testType === "interactive" || testType === 'retrieval') && this.state.eval !== "eval_3_results")  &&
+                                                    {((testType === "interactive" || testType === "retrieval" || testType === "multi retrieval") && this.state.eval !== "eval_3_results")  &&
                                                         <li className="nav-item" >
                                                             <button className={"Scorecard" === this.state.currentTab ? 'nav-link overview-nav-link active' : 'nav-link overview-nav-link'} onClick={() => this.toggleTab("Scorecard")}>Scorecard</button>
                                                         </li>


### PR DESCRIPTION
I thought there would be more than one place we were using the "retrieval" flag but this is the only place in the front end or back end UI code.  