### PR TITLE
MCS-1716:  Fix issue with duplicate charts on landing page

### DIFF
--- a/analysis-ui/src/components/Home/chartContainer.jsx
+++ b/analysis-ui/src/components/Home/chartContainer.jsx
@@ -137,7 +137,7 @@ class ChartContainer extends React.Component {
                             defaultValue={this.state.chartOption}
                         />
                     </div>
-                    {this.props.domainType.toLowerCase() !== 'agents' &&
+                    {this.props.domainType.toLowerCase() !== 'passive agents' &&
                         <div className="chart-weight-toggle">
                             <ToggleButtonGroup type="checkbox" value={this.state.isWeighted} onChange={this.handleWeightedToggle}>
                                 <ToggleButton variant="secondary" value={true}>{this.props.domainType.toLowerCase() === 'passive agents' ? 'Paired' : 'Weighted'}</ToggleButton>

--- a/analysis-ui/src/components/Home/homeCharts.jsx
+++ b/analysis-ui/src/components/Home/homeCharts.jsx
@@ -98,14 +98,14 @@ class HomeCharts extends React.Component {
                             if (error) return <div>Error</div>
 
                             let domainTypes = data[evalDomainTypes];
-                            domainTypes.sort((a, b) => (a._id.domainType > b._id.domainType) ? 1 : -1);
+                            domainTypes.sort();
                             
                             return (
                                 <div className='charts-container'>
                                     {
                                         domainTypes.map(domainType =>
                                             <Query query={get_home_chart_options} variables={
-                                                {"eval": this.state.currentEval.value, "evalType": domainType._id.domainType}} key={"home_chart_" + domainType._id.domainType}>
+                                                {"eval": this.state.currentEval.value, "evalType": domainType}} key={"home_chart_" + domainType}>
                                             {
                                                 ({ loading, error, data }) => {
                                                     if (loading) return <div>No stats yet</div> 
@@ -114,7 +114,7 @@ class HomeCharts extends React.Component {
                                                     const chartOptions = data[homeChartOptions]
 
                                                     return (
-                                                        <ChartContainer domainType={domainType._id.domainType} category={domainType._id.category} isPercent={this.state.numPercentToggle === 'percent'} 
+                                                        <ChartContainer domainType={domainType} isPercent={this.state.numPercentToggle === 'percent'} 
                                                             eval={this.state.currentEval} chartOptions={chartOptions} useDidNotAnswer={this.state.useDidNotAnswer}/>
 
                                                     )

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -497,11 +497,7 @@ const mcsResolvers = {
             return {results: results, sceneMap: sceneFieldLabelMapTable, historyMap: historyFieldLabelMapTable, historyCollection: mongoQueryObject.historyCollection};
         },
         getEvalDomainTypes: async(obj, args, context, infow)=> {
-            return await mcsDB.db.collection(args.eval).aggregate( 
-                [
-                    {"$group": { "_id": { domainType: "$domain_type", category: "$category" } } }
-                ]
-            ).toArray();;
+            return await mcsDB.db.collection(args["eval"]).distinct("domain_type").then(result => {return result});
         },
         getHomeChartOptions: async(obj, args, context, infow)=> {
             const metadata =  await mcsDB.db.collection(args.eval).distinct(


### PR DESCRIPTION
Added a fix for landing page "passive agents" should not show "paired/unpaired" like it used to do for "agents"