### PR TITLE
MCS-1780 - Add weighted toggle for seeing leads to knowing on home page

### DIFF
--- a/analysis-ui/src/components/Home/chartContainer.jsx
+++ b/analysis-ui/src/components/Home/chartContainer.jsx
@@ -123,6 +123,13 @@ class ChartContainer extends React.Component {
         return this.toUpperFirstLetters(this.props.domainType);
     }
 
+    displayWeightedToggle() {
+        // toggling weighting for passive agency only applies in
+        // Evals 6 and 7
+        return (this.props.domainType.toLowerCase() !== 'passive agents' ||
+            ["Evaluation 6 Results", "Evaluation 7 Results"].includes(this.props.eval.label));
+    }
+
     render() {
         return (
             <div className='chart-home-container'>
@@ -137,14 +144,16 @@ class ChartContainer extends React.Component {
                             defaultValue={this.state.chartOption}
                         />
                     </div>
-                    {this.props.domainType.toLowerCase() !== 'passive agents' &&
+
+                    {this.displayWeightedToggle() &&
                         <div className="chart-weight-toggle">
                             <ToggleButtonGroup type="checkbox" value={this.state.isWeighted} onChange={this.handleWeightedToggle}>
-                                <ToggleButton variant="secondary" value={true}>{this.props.domainType.toLowerCase() === 'passive agents' ? 'Paired' : 'Weighted'}</ToggleButton>
-                                <ToggleButton variant="secondary" value={false}>{this.props.domainType.toLowerCase() === 'passive agents' ? 'Unpaired' : 'Unweighted'}</ToggleButton>
+                                <ToggleButton variant="secondary" value={true}>Weighted</ToggleButton>
+                                <ToggleButton variant="secondary" value={false}>Unweighted</ToggleButton>
                             </ToggleButtonGroup>
                         </div>
                     }
+
                 </div>
                 <Query query={get_home_chart} variables={{
                         "eval": this.props.eval.value,

--- a/node-graphql/server.statsFunctions.js
+++ b/node-graphql/server.statsFunctions.js
@@ -219,9 +219,16 @@ function getChartData(isPlausibility, isPercent, scoreStats, isWeighted, evalTyp
         let incorrectCategoryStats = [];
 
         for(let i = 0; i < scoreStats.length; i++) {
+            // For passive agent tasks Eval 6+, we want to always weight (or pair) NYU agency
+            // tasks, but want to be able to toggle weighting for other passive agency tasks
+            // (like "seeing leads to knowing")
+            let useWeighted = isWeighted
+            if(scoreStats[i]["_id"]["category_type"].startsWith("agents")) {
+                useWeighted = true
+            }
             const performer = scoreStats[i]["_id"]["performer"];
-            const weightedValue = isWeighted ? scoreStats[i]["_id"]["weight"] : 1;
-            const isCorrect = isWeighted ? scoreStats[i]["_id"]["weight_score"] > 0 : scoreStats[i]["_id"]["correct"];
+            const weightedValue = useWeighted ? scoreStats[i]["_id"]["weight"] : 1;
+            const isCorrect = useWeighted ? scoreStats[i]["_id"]["weight_score"] > 0 : scoreStats[i]["_id"]["correct"];
             // Only Add Correct Items to Totals
             if(isCorrect) {
                 // Update Overall/Total


### PR DESCRIPTION
Should have weighted/unweighted toggle now for Passive Agency for Eval 6+ on the home page charts, but will only work for seeing leads to knowing. The other passive agency tasks will always be represented as weighted (or paired in this case).

Note that this was branched off of MCS-1786.