### PR TITLE
MCS-1429 - Fix for updating csv file links + minor UI fixes

### DIFF
--- a/analysis-ui/src/components/Analysis/navigation.jsx
+++ b/analysis-ui/src/components/Analysis/navigation.jsx
@@ -8,6 +8,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import { LinkContainer } from 'react-router-bootstrap';
 import Search from '@material-ui/icons/Search';
 import TextField from '@material-ui/core/TextField';
+import _ from "lodash";
 
 const GET_FIELD_AGG = gql`
     query getFieldAggregation($fieldName: String!){
@@ -107,7 +108,7 @@ class NavListItem extends React.Component {
                     button
                     selected={this.checkSelected()}
                     onClick={() => this.updateState(listItemValue, this.props.stateName)}>
-                    <ListItemText primary={listItemlabel} />
+                    <ListItemText primary={_.startCase(listItemlabel)} />
                 </ListItem>
             </LinkContainer>
         )

--- a/analysis-ui/src/components/Analysis/scorecard.jsx
+++ b/analysis-ui/src/components/Analysis/scorecard.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {Fragment, useState} from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button'
 
@@ -40,7 +40,7 @@ function ScoreCardModal({show, onHide, scorecardObject, currentSceneNum}) {
             <Modal.Body>
                 <div className="scene-table-div">
                     {scorecardObject !== undefined && Object.keys(scorecardObject).map((objectKey, key) => 
-                        <>
+                        <Fragment key={key}>
                             {isValueNonNullObject(scorecardObject, objectKey) &&
                                 <>
                                     {Object.keys(scorecardObject[objectKey]).length > 0 &&
@@ -66,7 +66,7 @@ function ScoreCardModal({show, onHide, scorecardObject, currentSceneNum}) {
                                     </div>
                                 </>
                             }
-                        </>
+                        </Fragment>
                     )}
                 </div>
             </Modal.Body>

--- a/node-graphql/csv-scripts/generate_csv.py
+++ b/node-graphql/csv-scripts/generate_csv.py
@@ -12,8 +12,11 @@ KEYS_INDEX = "collection_keys"
 def upload_csv_file(csv_file_name, bucket_name):
     s3 = boto3.resource('s3')
     bucket = s3.Bucket(bucket_name)
-    bucket.upload_file(Filename=csv_file_name, Key=EVALUATION_PREFIX + csv_file_name)
-
+    bucket.upload_file(Filename=csv_file_name, Key=EVALUATION_PREFIX + csv_file_name,
+        ExtraArgs={
+            "CacheControl": "max-age=0"
+        }
+    )
 
 def create_csv_file(db_index, eval_name, db_string, bucket_name):
     client = MongoClient('mongodb://mongomcs:mongomcspassword@mcs-mongo:27017/' + db_string)


### PR DESCRIPTION
MCS-1429 specific changes are in generate_csv.py. Messed with different cache-control settings (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) so that the csv file response doesn't get reused. Seems like you need to do it upfront (before you've ever created a file) and on upload for it to work correctly + our current csvs wouldn't have any updates at this point anyway, so I tested by using a separate local test script creating a new test csv file to upload to dev-evaluation-images with the cache-control setting specified, and making minor updates to the csv file each time.

The fixes in the other analysis-ui are minor things like getting rid of console.log / Unique "key" prop errors, and making sure the categories are capitalized in the Scene Analysis view like they are in Test Overview. 