### PR TITLE
MCS-1828set default to sorting for firefox

### DIFF
--- a/analysis-ui/src/components/Analysis/scoreTable.jsx
+++ b/analysis-ui/src/components/Analysis/scoreTable.jsx
@@ -13,7 +13,7 @@ import Scorecard from './scorecard';
 function ScoreTable({columns, currentPerformerScenes, currentSceneNum, 
     changeSceneHandler, scenesInOrder, constantsObject, sortable, isInteractive}) {
 
-    const [sortOption, setSortOption] = useState({sortBy: "", sortOrder: "asc"})
+    const [sortOption, setSortOption] = useState({sortBy: "scene_num", sortOrder: "asc"})
 
     const getSorting = (order, orderBy) => {
         return order === "desc"


### PR DESCRIPTION
Added a default sortby in SortTable.  Seems to default sorting by scene_name ascending in Firefox now.  Retested in Chrome, didn't see any issues.

![image](https://github.com/NextCenturyCorporation/mcs-ui/assets/62263242/1923110c-0174-408f-a605-db60743c299a)
