### PR TITLE
MCS-1956 - Make new distance field visible within query builder

### DIFF
--- a/node-graphql/server.fieldMappings.js
+++ b/node-graphql/server.fieldMappings.js
@@ -73,7 +73,8 @@ const historyFieldLabelMapTable= {
     "score.weighted_score_worth": "Weighted Evaluation Score Value",
     "score.weighted_confidence": "Weighted Score/Confidence",
     "score.weighted_score": "Weighted Evaluation Score",
-    "scene_goal_id": "Cube/Scene Goal ID"
+    "scene_goal_id": "Cube/Scene Goal ID",
+    "start_distance_between_performer_and_target": "Start Distance Between Performer and Target"
 };
 
 const historyFieldLabelMap = {
@@ -99,8 +100,7 @@ const historyFieldLabelMap = {
     "score.weighted_score_worth": "Weighted Evaluation Score Value",
     "score.weighted_confidence": "Weighted Score/Confidence",
     "score.weighted_score": "Weighted Evaluation Score",
-    "scene_goal_id": "Cube/Scene Goal ID",
-    "start_distance_between_performer_and_target": "Start Distance Between Performer and Target"
+    "scene_goal_id": "Cube/Scene Goal ID"
 };
 
 const sceneExcludeFields = [

--- a/node-graphql/server.fieldMappings.js
+++ b/node-graphql/server.fieldMappings.js
@@ -48,7 +48,8 @@ const historyIncludeFieldsTable = [
     "score.weighted_score_worth",
     "score.weighted_confidence",
     "score.weighted_score",
-    "scene_goal_id"
+    "scene_goal_id",
+    "start_distance_between_performer_and_target"
 ];
 
 const historyFieldLabelMapTable= {
@@ -98,7 +99,8 @@ const historyFieldLabelMap = {
     "score.weighted_score_worth": "Weighted Evaluation Score Value",
     "score.weighted_confidence": "Weighted Score/Confidence",
     "score.weighted_score": "Weighted Evaluation Score",
-    "scene_goal_id": "Cube/Scene Goal ID"
+    "scene_goal_id": "Cube/Scene Goal ID",
+    "start_distance_between_performer_and_target": "Start Distance Between Performer and Target"
 };
 
 const sceneExcludeFields = [


### PR DESCRIPTION
Minor change needed to see the start_distance_between_performer_and_target field within the UI

Ingest PR here: https://github.com/NextCenturyCorporation/mcs-ingest/pull/139