### PR TITLE
MCS-1965 - Adding important tags for Set Rotation in Eval 7

### DIFF
--- a/node-graphql/server.fieldMappings.js
+++ b/node-graphql/server.fieldMappings.js
@@ -484,7 +484,12 @@ const sceneFieldLabelMap = {
     "goal.sceneInfo.targetBehind": "Target Behind",
     "goal.sceneInfo.occludersTrained": "Occluders Trained",
     "goal.sceneInfo.targetHidden": "Target Hidden",
-    "goal.sceneInfo.id": "Cube ID"
+    "goal.sceneInfo.id": "Cube ID",
+    "goal.sceneInfo.containerBaited": "Container Baited",
+    "goal.sceneInfo.containerBaitedIndex": "Container Baited Index",
+    "goal.sceneInfo.landmark": "Landmark",
+    "goal.sceneInfo.landmarkIndex": "Landmark Index",
+    "goal.sceneInfo.landmarkColor": "Landmark Color"
 };
 
 const sceneFieldLabelMapTable = {
@@ -527,7 +532,12 @@ const sceneFieldLabelMapTable = {
     "goal.sceneInfo.movement": "Hypercube Movement",
     "goal.habituation_total": "Habituation Total",
     "goal.answer.choice": "Goal Answer Choice",
-    "goal.sceneInfo.id": "Cube ID"
+    "goal.sceneInfo.id": "Cube ID",
+    "goal.sceneInfo.containerBaited": "Container Baited",
+    "goal.sceneInfo.containerBaitedIndex": "Container Baited Index",
+    "goal.sceneInfo.landmark": "Landmark",
+    "goal.sceneInfo.landmarkIndex": "Landmark Index",
+    "goal.sceneInfo.landmarkColor": "Landmark Color"
 };
 
 const sceneIncludeFieldsTable = [
@@ -571,7 +581,12 @@ const sceneIncludeFieldsTable = [
     "goal.sceneInfo.movement",
     "goal.habituation_total",
     "goal.answer.choice",
-    "goal.sceneInfo.id"
+    "goal.sceneInfo.id",
+    "goal.sceneInfo.containerBaited",
+    "goal.sceneInfo.containerBaitedIndex",
+    "goal.sceneInfo.landmark",
+    "goal.sceneInfo.landmarkIndex",
+    "goal.sceneInfo.landmarkColor"
 ];
 
 module.exports = {


### PR DESCRIPTION
(Note that this was branched off of MCS-1956).

Once again, if the fields aren't appearing in the scenes CSV file when we actually run the eval, we'll just need to run the update_collection_keys_if_missing.py on the ingest side (I ran this locally to test). Verified that the tags mentioned in this ticket are already saved in ingest properly within the scene record, these minor changes here are just needed so that Koleen will also be able to see + query on these fields in the query builder. 
