### PR TITLE
MCS-1971 - Incorporate new scorecard values for eval 7 

### DIFF
--- a/analysis-ui/src/components/TestOverview/scorecardTable.jsx
+++ b/analysis-ui/src/components/TestOverview/scorecardTable.jsx
@@ -50,6 +50,12 @@ const scorecardFieldsLatest = [
     {"title": "Rotate Tool Failures", "key": "totalRotateToolFailure"},
     {"title": "Torque Tool Successes", "key": "totalTorqueToolSuccess"},
     {"title": "Torque Tool Failures", "key": "totalTorqueToolFailure"},
+    // Added for Eval 7
+    {"title": "Tools Used In Scene", "key": "totalToolsUsed"},
+    {"title": "Hooked Tools Rotated", "key": "totalHookedToolRotated"},
+    {"title": "Straight Tools Rotated", "key": "totalStraightToolRotated"},
+    {"title": "Stepped In Lava", "key": "totalSteppedInLava"},
+    // End Eval 7 specific fields
     {"title": "Pickup Non-Target", "key": "totalPickupNonTarget"},
     {"title": "Pickup Not Pickupable", "key": "totalPickupNotPickupable"},
     {"title": "Interact With Non Agent", "key": "totalInteractWithNonAgent"},
@@ -57,6 +63,7 @@ const scorecardFieldsLatest = [
     {"title": "Walked Into Structures", "key": "totalWalkedIntoStructures"},
     {"title": "Interact With Blob First", "key": "totalInteractWithBlobFirst"}
 ];
+
 class ScoreCardTable extends React.Component {
 
     getTotalScoreCardValue(scorecardData, key) {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -697,12 +697,29 @@ const mcsResolvers = {
                 "totalRotateToolFailure": { "$sum" : "$score.scorecard.tool_usage.RotateObject_failed" },
                 "totalTorqueToolSuccess": { "$sum" : "$score.scorecard.tool_usage.TorqueObject" },
                 "totalTorqueToolFailure": { "$sum" : "$score.scorecard.tool_usage.TorqueObject_failed" },
+                // multi tool use stats
+                "totalToolsUsed": { "$sum" : "$score.scorecard.tool_usage.total_tools_used" },
+                "totalHookedToolRotated": {
+                    "$sum": {
+                        "$cond": [ "$score.scorecard.tool_usage.is_hooked_rotated", 1, 0 ]
+                    }
+                },
+                "totalStraightToolRotated": {
+                    "$sum": {
+                        "$cond": [ "$score.scorecard.tool_usage.is_straight_rotated", 1, 0 ]
+                    }
+                },
+                // end tool use stats
+                "totalSteppedInLava": {
+                    "$sum": {
+                        "$cond": [ "$score.scorecard.stepped_in_lava", 1, 0 ]
+                    }
+                },
                 "totalPickupNonTarget": {
                     "$sum": {
                         "$cond": [ "$score.scorecard.pickup_non_target", 1, 0 ]
                     }
                 },
-                // end tool use stats
                 "totalPickupNotPickupable": { "$sum" : "$score.scorecard.pickup_not_pickupable" },
                 "totalInteractWithNonAgent": { "$sum" : "$score.scorecard.interact_with_non_agent" },
                 "totalInteractWithAgent": { "$sum" : "$score.scorecard.interact_with_agent" },


### PR DESCRIPTION
See ingest PR here: 
https://github.com/NextCenturyCorporation/mcs-ingest/pull/140

On the Test Overview page, I put the values next to the other tool use ones as opposed to adding them to the end of the list, in case anyone has trouble finding them. 